### PR TITLE
Added LD_RUNPATH_SEARCH_PATHS to look for dylibs

### DIFF
--- a/SFBAudioEngine.xcodeproj/project.pbxproj
+++ b/SFBAudioEngine.xcodeproj/project.pbxproj
@@ -896,7 +896,7 @@
 					"$(SRCROOT)/Libraries/macosx-x86_64-clang-libc++/lib",
 					"$(PROJECT_DIR)/Libraries/macosx-x86_64-clang-libc++/lib",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.7;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				OTHER_LDFLAGS = (
 					"-ldumb",
 					"-lFLAC",
@@ -935,7 +935,7 @@
 					"$(SRCROOT)/Libraries/macosx-x86_64-clang-libc++/lib",
 					"$(PROJECT_DIR)/Libraries/macosx-x86_64-clang-libc++/lib",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.7;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				OTHER_LDFLAGS = (
 					"-ldumb",
 					"-lFLAC",

--- a/SFBAudioEngine.xcodeproj/project.pbxproj
+++ b/SFBAudioEngine.xcodeproj/project.pbxproj
@@ -891,6 +891,7 @@
 				HEADER_SEARCH_PATHS = "$(SRCROOT)/Libraries/macosx-x86_64-clang-libc++/include";
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "@rpath";
+				LD_RUNPATH_SEARCH_PATHS = "@loader_path/Libraries";
 				LIBRARY_SEARCH_PATHS = (
 					"$(SRCROOT)/Libraries/macosx-x86_64-clang-libc++/lib",
 					"$(PROJECT_DIR)/Libraries/macosx-x86_64-clang-libc++/lib",
@@ -929,6 +930,7 @@
 				HEADER_SEARCH_PATHS = "$(SRCROOT)/Libraries/macosx-x86_64-clang-libc++/include";
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "@rpath";
+				LD_RUNPATH_SEARCH_PATHS = "@loader_path/Libraries";
 				LIBRARY_SEARCH_PATHS = (
 					"$(SRCROOT)/Libraries/macosx-x86_64-clang-libc++/lib",
 					"$(PROJECT_DIR)/Libraries/macosx-x86_64-clang-libc++/lib",


### PR DESCRIPTION
Nobody wants to see:

```
dyld: Library not loaded: @rpath/libmpg123.0.dylib
  Referenced from: /Users/joshua/Library/Developer/.../Debug/SFBAudioEngine.framework/Versions/A/SFBAudioEngine
  Reason: image not found
```

So, setting a path lets it be found :)

(It's set to mirror the setting in "Build Phases".)
