### PR TITLE
Added CF creation helpers to CFWrapper

### DIFF
--- a/CFErrorUtilities.cpp
+++ b/CFErrorUtilities.cpp
@@ -35,7 +35,7 @@ CFErrorRef SFB::CreateError(CFStringRef domain, CFIndex code, CFStringRef descri
 	if(nullptr == domain)
 		return nullptr;
 	
-	SFB::CFMutableDictionary errorDictionary(CFDictionaryCreateMutable(kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+	SFB::CFMutableDictionary errorDictionary(0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
 	if(!errorDictionary)
 		return nullptr;
 	
@@ -56,7 +56,7 @@ CFErrorRef SFB::CreateErrorForURL(CFStringRef domain, CFIndex code, CFStringRef 
 	if(nullptr == domain)
 		return nullptr;
 	
-	SFB::CFMutableDictionary errorDictionary(CFDictionaryCreateMutable(kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+	SFB::CFMutableDictionary errorDictionary(0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
 	if(!errorDictionary)
 		return nullptr;
 
@@ -65,7 +65,7 @@ CFErrorRef SFB::CreateErrorForURL(CFStringRef domain, CFIndex code, CFStringRef 
 
 		SFB::CFString displayName(CreateDisplayNameForURL(url));
 		if(displayName) {
-			SFB::CFString description(CFStringCreateWithFormat(kCFAllocatorDefault, nullptr, descriptionFormatStringForURL, displayName.Object()));
+			SFB::CFString description(nullptr, descriptionFormatStringForURL, displayName.Object());
 			if(description)
 				CFDictionarySetValue(errorDictionary, kCFErrorLocalizedDescriptionKey, description);
 		}

--- a/CFWrapper.h
+++ b/CFWrapper.h
@@ -224,6 +224,65 @@ namespace SFB {
 
 		//@}
 
+
+		// ========================================
+		/*! @name CoreFoundation object creation */
+		//@{
+
+		/*! @brief Create a new wrapped \c CFStringRef using \c CFStringCreateWithCString with the default allocator */
+		template <typename = std::enable_if<std::is_same<T, CFStringRef>::value>>
+		CFWrapper(const char *cStr, CFStringEncoding encoding)
+			: CFWrapper(CFStringCreateWithCString(kCFAllocatorDefault, cStr, encoding))
+		{}
+
+		/*! @brief Create a new wrapped \c CFStringRef using \c CFStringCreateWithFormatAndArguments with the default allocator */
+		template <typename = std::enable_if<std::is_same<T, CFStringRef>::value>>
+		CFWrapper(CFDictionaryRef formatOptions, CFStringRef format, ...) CF_FORMAT_FUNCTION(3,4)
+		{
+			va_list ap;
+			va_start(ap, format);
+			*this = CFStringCreateWithFormatAndArguments(kCFAllocatorDefault, formatOptions, format, ap);
+			va_end(ap);
+		}
+
+		/*! @brief Create a new wrapped \c CFNumberRef using \c CFNumberCreate with the default allocator */
+		template <typename = std::enable_if<std::is_same<T, CFNumberRef>::value>>
+		CFWrapper(CFNumberType theType, const void *valuePtr)
+			: CFWrapper(CFNumberCreate(kCFAllocatorDefault, theType, valuePtr))
+		{}
+
+		/*! @brief Create a new wrapped \c CFArrayRef using \c CFArrayCreate with the default allocator */
+		template <typename = std::enable_if<std::is_same<T, CFArrayRef>::value>>
+		CFWrapper(const void **values, CFIndex numValues, const CFArrayCallBacks *callBacks)
+			: CFWrapper(CFArrayCreate(kCFAllocatorDefault, values, numValues, callBacks))
+		{}
+
+		/*! @brief Create a new wrapped \c CFMutableArrayRef using \c CFArrayCreateMutable with the default allocator */
+		template <typename = std::enable_if<std::is_same<T, CFMutableArrayRef>::value>>
+		CFWrapper(CFIndex capacity, const CFArrayCallBacks *callBacks)
+			: CFWrapper(CFArrayCreateMutable(kCFAllocatorDefault, capacity, callBacks))
+		{}
+
+		/*! @brief Create a new wrapped \c CFDictionaryRef using \c CFDictionaryCreate with the default allocator */
+		template <typename = std::enable_if<std::is_same<T, CFDictionaryRef>::value>>
+		CFWrapper(const void **keys, const void **values, CFIndex numValues, const CFDictionaryKeyCallBacks *keyCallBacks, const CFDictionaryValueCallBacks *valueCallBacks)
+			: CFWrapper(CFDictionaryCreate(kCFAllocatorDefault, keys, values, numValues, keyCallBacks, valueCallBacks))
+		{}
+
+		/*! @brief Create a new wrapped \c CFMutableDictionaryRef using \c CFDictionaryCreateMutable with the default allocator */
+		template <typename = std::enable_if<std::is_same<T, CFMutableDictionaryRef>::value>>
+		CFWrapper(CFIndex capacity, const CFDictionaryKeyCallBacks *keyCallBacks, const CFDictionaryValueCallBacks *valueCallBacks)
+			: CFWrapper(CFDictionaryCreateMutable(kCFAllocatorDefault, capacity, keyCallBacks, valueCallBacks))
+		{}
+
+		/*! @brief Create a new wrapped \c CFDataRef using \c CFDataCreate with the default allocator */
+		template <typename = std::enable_if<std::is_same<T, CFDataRef>::value>>
+		CFWrapper(const UInt8 *bytes, CFIndex length)
+			: CFWrapper(CFDataCreate(kCFAllocatorDefault, bytes, length))
+		{}
+
+		//@}
+
 	private:
 		T mObject;				/*!< The Core Foundation object */
 		bool mRelease;			/*!< Whether \c CFRelease should be called on destruction or reassignment */

--- a/CreateStringForOSType.cpp
+++ b/CreateStringForOSType.cpp
@@ -33,5 +33,5 @@ SFB::CFString SFB::StringForOSType(OSType osType)
 	unsigned char formatID [4];
 	*(UInt32 *)formatID = OSSwapHostToBigInt32(osType);
 
-    return CFString(CFStringCreateWithFormat(kCFAllocatorDefault, nullptr, CFSTR("%.4s"), formatID));
+    return CFString(nullptr, CFSTR("%.4s"), formatID);
 }

--- a/Decoders/DSDIFFDecoder.cpp
+++ b/Decoders/DSDIFFDecoder.cpp
@@ -762,11 +762,10 @@ bool SFB::Audio::DSDIFFDecoder::_Close(CFErrorRef */*error*/)
 
 SFB::CFString SFB::Audio::DSDIFFDecoder::_GetSourceFormatDescription() const
 {
-	return CFString(CFStringCreateWithFormat(kCFAllocatorDefault,
-											 nullptr,
-											 CFSTR("DSD Interchange File Format, %u channels, %u Hz"),
-											 (unsigned int)mSourceFormat.mChannelsPerFrame,
-											 (unsigned int)mSourceFormat.mSampleRate));
+	return CFString(nullptr,
+					CFSTR("DSD Interchange File Format, %u channels, %u Hz"),
+					(unsigned int)mSourceFormat.mChannelsPerFrame,
+					(unsigned int)mSourceFormat.mSampleRate);
 }
 
 UInt32 SFB::Audio::DSDIFFDecoder::_ReadAudio(AudioBufferList *bufferList, UInt32 frameCount)

--- a/Decoders/DSFDecoder.cpp
+++ b/Decoders/DSFDecoder.cpp
@@ -264,11 +264,10 @@ bool SFB::Audio::DSFDecoder::_Close(CFErrorRef */*error*/)
 
 SFB::CFString SFB::Audio::DSFDecoder::_GetSourceFormatDescription() const
 {
-	return CFString(CFStringCreateWithFormat(kCFAllocatorDefault,
-											 nullptr,
-											 CFSTR("DSD Stream File, %u channels, %u Hz"),
-											 (unsigned int)mSourceFormat.mChannelsPerFrame,
-											 (unsigned int)mSourceFormat.mSampleRate));
+	return CFString(nullptr,
+					CFSTR("DSD Stream File, %u channels, %u Hz"),
+					(unsigned int)mSourceFormat.mChannelsPerFrame,
+					(unsigned int)mSourceFormat.mSampleRate);
 }
 
 UInt32 SFB::Audio::DSFDecoder::_ReadAudio(AudioBufferList *bufferList, UInt32 frameCount)

--- a/Decoders/FLACDecoder.cpp
+++ b/Decoders/FLACDecoder.cpp
@@ -363,11 +363,10 @@ bool SFB::Audio::FLACDecoder::_Close(CFErrorRef */*error*/)
 
 SFB::CFString SFB::Audio::FLACDecoder::_GetSourceFormatDescription() const
 {
-	return CFString(CFStringCreateWithFormat(kCFAllocatorDefault,
-											 nullptr,
-											 CFSTR("FLAC, %u channels, %u Hz"),
-											 (unsigned int)mSourceFormat.mChannelsPerFrame,
-											 (unsigned int)mSourceFormat.mSampleRate));
+	return CFString(nullptr,
+					CFSTR("FLAC, %u channels, %u Hz"),
+					(unsigned int)mSourceFormat.mChannelsPerFrame,
+					(unsigned int)mSourceFormat.mSampleRate);
 }
 
 UInt32 SFB::Audio::FLACDecoder::_ReadAudio(AudioBufferList *bufferList, UInt32 frameCount)

--- a/Decoders/LibsndfileDecoder.cpp
+++ b/Decoders/LibsndfileDecoder.cpp
@@ -110,7 +110,7 @@ CFArrayRef SFB::Audio::LibsndfileDecoder::CreateSupportedFileExtensions()
 		SF_FORMAT_INFO formatInfo;
 		formatInfo.format = i;
 		if(0 == sf_command(nullptr, SFC_GET_FORMAT_MAJOR, &formatInfo, sizeof(formatInfo))) {
-			SFB::CFString extension(CFStringCreateWithCString(kCFAllocatorDefault, formatInfo.extension, kCFStringEncodingUTF8));
+			SFB::CFString extension(formatInfo.extension, kCFStringEncodingUTF8);
 			if(extension)
 				CFArrayAppendValue(supportedExtensions, extension);
 		}
@@ -361,12 +361,11 @@ SFB::CFString SFB::Audio::LibsndfileDecoder::_GetSourceFormatDescription() const
 		return CFString();
 	}
 	
-	return CFString(CFStringCreateWithFormat(kCFAllocatorDefault,
-											 nullptr,
-											 CFSTR("%s, %u channels, %u Hz"),
-											 formatInfo.name,
-											 mSourceFormat.mChannelsPerFrame,
-											 (unsigned int)mSourceFormat.mSampleRate));
+	return CFString(nullptr,
+					CFSTR("%s, %u channels, %u Hz"),
+					formatInfo.name,
+					mSourceFormat.mChannelsPerFrame,
+					(unsigned int)mSourceFormat.mSampleRate);
 }
 
 UInt32 SFB::Audio::LibsndfileDecoder::_ReadAudio(AudioBufferList *bufferList, UInt32 frameCount)

--- a/Decoders/MODDecoder.cpp
+++ b/Decoders/MODDecoder.cpp
@@ -231,11 +231,10 @@ bool SFB::Audio::MODDecoder::_Close(CFErrorRef */*error*/)
 
 SFB::CFString SFB::Audio::MODDecoder::_GetSourceFormatDescription() const
 {
-	return CFString(CFStringCreateWithFormat(kCFAllocatorDefault,
-											 nullptr,
-											 CFSTR("MOD, %u channels, %u Hz"),
-											 mSourceFormat.mChannelsPerFrame,
-											 (unsigned int)mSourceFormat.mSampleRate));
+	return CFString(nullptr,
+					CFSTR("MOD, %u channels, %u Hz"),
+					mSourceFormat.mChannelsPerFrame,
+					(unsigned int)mSourceFormat.mSampleRate);
 }
 
 UInt32 SFB::Audio::MODDecoder::_ReadAudio(AudioBufferList *bufferList, UInt32 frameCount)

--- a/Decoders/MPEGDecoder.cpp
+++ b/Decoders/MPEGDecoder.cpp
@@ -286,11 +286,10 @@ SFB::CFString SFB::Audio::MPEGDecoder::_GetSourceFormatDescription() const
 {
 	mpg123_frameinfo mi;
 	if(MPG123_OK != mpg123_info(mDecoder.get(), &mi)) {
-		return CFString(CFStringCreateWithFormat(kCFAllocatorDefault,
-												 nullptr,
-												 CFSTR("MPEG-1 Audio, %u channels, %u Hz"),
-												 (unsigned int)mSourceFormat.mChannelsPerFrame,
-												 (unsigned int)mSourceFormat.mSampleRate));
+		return CFString(nullptr,
+						CFSTR("MPEG-1 Audio, %u channels, %u Hz"),
+						(unsigned int)mSourceFormat.mChannelsPerFrame,
+						(unsigned int)mSourceFormat.mSampleRate);
 	}
 
 	CFStringRef layerDescription = nullptr;
@@ -308,12 +307,11 @@ SFB::CFString SFB::Audio::MPEGDecoder::_GetSourceFormatDescription() const
 		case MPG123_M_STEREO:			channelDescription = CFSTR("Stereo");			break;
 	}
 
-	return CFString(CFStringCreateWithFormat(kCFAllocatorDefault,
-											 nullptr,
-											 CFSTR("MPEG-1 Audio (%@), %@, %u Hz"),
-											 layerDescription,
-											 channelDescription,
-											 (unsigned int)mSourceFormat.mSampleRate));
+	return CFString(nullptr,
+					CFSTR("MPEG-1 Audio (%@), %@, %u Hz"),
+					layerDescription,
+					channelDescription,
+					(unsigned int)mSourceFormat.mSampleRate);
 }
 
 UInt32 SFB::Audio::MPEGDecoder::_ReadAudio(AudioBufferList *bufferList, UInt32 frameCount)

--- a/Decoders/MonkeysAudioDecoder.cpp
+++ b/Decoders/MonkeysAudioDecoder.cpp
@@ -262,11 +262,10 @@ bool SFB::Audio::MonkeysAudioDecoder::_Close(CFErrorRef */*error*/)
 
 SFB::CFString SFB::Audio::MonkeysAudioDecoder::_GetSourceFormatDescription() const
 {
-	return CFString(CFStringCreateWithFormat(kCFAllocatorDefault,
-											 nullptr,
-											 CFSTR("Monkey's Audio, %u channels, %u Hz"),
-											 mSourceFormat.mChannelsPerFrame,
-											 (unsigned int)mSourceFormat.mSampleRate));
+	return CFString(nullptr,
+					CFSTR("Monkey's Audio, %u channels, %u Hz"),
+					mSourceFormat.mChannelsPerFrame,
+					(unsigned int)mSourceFormat.mSampleRate);
 }
 
 UInt32 SFB::Audio::MonkeysAudioDecoder::_ReadAudio(AudioBufferList *bufferList, UInt32 frameCount)

--- a/Decoders/MusepackDecoder.cpp
+++ b/Decoders/MusepackDecoder.cpp
@@ -241,11 +241,10 @@ bool SFB::Audio::MusepackDecoder::_Close(CFErrorRef */*error*/)
 
 SFB::CFString SFB::Audio::MusepackDecoder::_GetSourceFormatDescription() const
 {
-	return CFString(CFStringCreateWithFormat(kCFAllocatorDefault,
-											 nullptr,
-											 CFSTR("Musepack, %u channels, %u Hz"),
-											 mSourceFormat.mChannelsPerFrame,
-											 (unsigned int)mSourceFormat.mSampleRate));
+	return CFString(nullptr,
+					CFSTR("Musepack, %u channels, %u Hz"),
+					mSourceFormat.mChannelsPerFrame,
+					(unsigned int)mSourceFormat.mSampleRate);
 }
 
 UInt32 SFB::Audio::MusepackDecoder::_ReadAudio(AudioBufferList *bufferList, UInt32 frameCount)

--- a/Decoders/OggOpusDecoder.cpp
+++ b/Decoders/OggOpusDecoder.cpp
@@ -226,11 +226,10 @@ bool SFB::Audio::OggOpusDecoder::_Close(CFErrorRef */*error*/)
 
 SFB::CFString SFB::Audio::OggOpusDecoder::_GetSourceFormatDescription() const
 {
-	return CFString(CFStringCreateWithFormat(kCFAllocatorDefault,
-											 nullptr,
-											 CFSTR("Ogg Opus, %u channels, %u Hz"),
-											 (unsigned int)mSourceFormat.mChannelsPerFrame,
-											 (unsigned int)mSourceFormat.mSampleRate));
+	return CFString(nullptr,
+					CFSTR("Ogg Opus, %u channels, %u Hz"),
+					(unsigned int)mSourceFormat.mChannelsPerFrame,
+					(unsigned int)mSourceFormat.mSampleRate);
 }
 
 UInt32 SFB::Audio::OggOpusDecoder::_ReadAudio(AudioBufferList *bufferList, UInt32 frameCount)

--- a/Decoders/OggSpeexDecoder.cpp
+++ b/Decoders/OggSpeexDecoder.cpp
@@ -347,11 +347,10 @@ bool SFB::Audio::OggSpeexDecoder::_Close(CFErrorRef */*error*/)
 
 SFB::CFString SFB::Audio::OggSpeexDecoder::_GetSourceFormatDescription() const
 {
-	return CFString(CFStringCreateWithFormat(kCFAllocatorDefault,
-											 nullptr,
-											 CFSTR("Ogg Speex, %u channels, %u Hz"),
-											 (unsigned int)mSourceFormat.mChannelsPerFrame,
-											 (unsigned int)mSourceFormat.mSampleRate));
+	return CFString(nullptr,
+					CFSTR("Ogg Speex, %u channels, %u Hz"),
+					(unsigned int)mSourceFormat.mChannelsPerFrame,
+					(unsigned int)mSourceFormat.mSampleRate);
 }
 
 UInt32 SFB::Audio::OggSpeexDecoder::_ReadAudio(AudioBufferList *bufferList, UInt32 frameCount)

--- a/Decoders/OggVorbisDecoder.cpp
+++ b/Decoders/OggVorbisDecoder.cpp
@@ -247,11 +247,10 @@ bool SFB::Audio::OggVorbisDecoder::_Close(CFErrorRef */*error*/)
 
 SFB::CFString SFB::Audio::OggVorbisDecoder::_GetSourceFormatDescription() const
 {
-	return CFString(CFStringCreateWithFormat(kCFAllocatorDefault,
-											 nullptr,
-											 CFSTR("Ogg Vorbis, %u channels, %u Hz"),
-											 (unsigned int)mSourceFormat.mChannelsPerFrame,
-											 (unsigned int)mSourceFormat.mSampleRate));
+	return CFString(nullptr,
+					CFSTR("Ogg Vorbis, %u channels, %u Hz"),
+					(unsigned int)mSourceFormat.mChannelsPerFrame,
+					(unsigned int)mSourceFormat.mSampleRate);
 }
 
 UInt32 SFB::Audio::OggVorbisDecoder::_ReadAudio(AudioBufferList *bufferList, UInt32 frameCount)

--- a/Decoders/TrueAudioDecoder.cpp
+++ b/Decoders/TrueAudioDecoder.cpp
@@ -218,11 +218,10 @@ bool SFB::Audio::TrueAudioDecoder::_Close(CFErrorRef */*error*/)
 
 SFB::CFString SFB::Audio::TrueAudioDecoder::_GetSourceFormatDescription() const
 {
-	return CFString(CFStringCreateWithFormat(kCFAllocatorDefault,
-											 nullptr,
-											 CFSTR("True Audio, %u channels, %u Hz"),
-											 (unsigned int)mSourceFormat.mChannelsPerFrame,
-											 (unsigned int)mSourceFormat.mSampleRate));
+	return CFString(nullptr,
+					CFSTR("True Audio, %u channels, %u Hz"),
+					(unsigned int)mSourceFormat.mChannelsPerFrame,
+					(unsigned int)mSourceFormat.mSampleRate);
 }
 
 UInt32 SFB::Audio::TrueAudioDecoder::_ReadAudio(AudioBufferList *bufferList, UInt32 frameCount)

--- a/Decoders/WavPackDecoder.cpp
+++ b/Decoders/WavPackDecoder.cpp
@@ -285,11 +285,10 @@ bool SFB::Audio::WavPackDecoder::_Close(CFErrorRef */*error*/)
 
 SFB::CFString SFB::Audio::WavPackDecoder::_GetSourceFormatDescription() const
 {
-	return CFString(CFStringCreateWithFormat(kCFAllocatorDefault,
-											 nullptr,
-											 CFSTR("WavPack, %u channels, %u Hz"),
-											 (unsigned int)mSourceFormat.mChannelsPerFrame,
-											 (unsigned int)mSourceFormat.mSampleRate));
+	return CFString(nullptr,
+					CFSTR("WavPack, %u channels, %u Hz"),
+					(unsigned int)mSourceFormat.mChannelsPerFrame,
+					(unsigned int)mSourceFormat.mSampleRate);
 }
 
 UInt32 SFB::Audio::WavPackDecoder::_ReadAudio(AudioBufferList *bufferList, UInt32 frameCount)

--- a/Input/HTTPInputSource.cpp
+++ b/Input/HTTPInputSource.cpp
@@ -66,7 +66,7 @@ bool SFB::HTTPInputSource::_Open(CFErrorRef *error)
 
 	// Seek support
 	if(0 < mDesiredOffset) {
-		SFB::CFString byteRange(CFStringCreateWithFormat(kCFAllocatorDefault, nullptr, CFSTR("bytes=%lld-"), mDesiredOffset));
+		SFB::CFString byteRange(nullptr, CFSTR("bytes=%lld-"), mDesiredOffset);
 		CFHTTPMessageSetHeaderFieldValue(mRequest, CFSTR("Range"), byteRange);
 	}
 

--- a/Metadata/AddAPETagToDictionary.cpp
+++ b/Metadata/AddAPETagToDictionary.cpp
@@ -42,7 +42,7 @@ bool SFB::Audio::AddAPETagToDictionary(CFMutableDictionaryRef dictionary, std::v
 	if(tag->isEmpty())
 		return true;
 
-	SFB::CFMutableDictionary additionalMetadata(CFDictionaryCreateMutable(kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+	SFB::CFMutableDictionary additionalMetadata(0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
 	
 	for(auto iterator : tag->itemListMap()) {
 		auto item = iterator.second;
@@ -51,8 +51,8 @@ bool SFB::Audio::AddAPETagToDictionary(CFMutableDictionaryRef dictionary, std::v
 			continue;
 
 		if(TagLib::APE::Item::Text == item.type()) {
-			SFB::CFString key(CFStringCreateWithCString(kCFAllocatorDefault, item.key().toCString(true), kCFStringEncodingUTF8));
-			SFB::CFString value(CFStringCreateWithCString(kCFAllocatorDefault, item.toString().toCString(true), kCFStringEncodingUTF8));
+			SFB::CFString key(item.key().toCString(true), kCFStringEncodingUTF8);
+			SFB::CFString value(item.toString().toCString(true), kCFStringEncodingUTF8);
 
 			if(kCFCompareEqualTo == CFStringCompare(key, CFSTR("ALBUM"), kCFCompareCaseInsensitive))
 				CFDictionarySetValue(dictionary, Metadata::kAlbumTitleKey, value);
@@ -129,11 +129,11 @@ bool SFB::Audio::AddAPETagToDictionary(CFMutableDictionaryRef dictionary, std::v
 					TagLib::FLAC::Picture picture;
 					picture.parse(decodedBlock);
 
-					SFB::CFData data(CFDataCreate(kCFAllocatorDefault, (const UInt8 *)picture.data().data(), picture.data().size()));
+					SFB::CFData data((const UInt8 *)picture.data().data(), picture.data().size());
 
 					SFB::CFString description = nullptr;
 					if(!picture.description().isNull())
-						description(CFStringCreateWithCString(kCFAllocatorDefault, picture.description().toCString(true), kCFStringEncodingUTF8));
+						description(picture.description().toCString(true), kCFStringEncodingUTF8);
 
 					attachedPictures.push_back(std::make_shared<AttachedPicture>(data, (AttachedPicture::Type)picture.type(), description));
 				}
@@ -144,7 +144,7 @@ bool SFB::Audio::AddAPETagToDictionary(CFMutableDictionaryRef dictionary, std::v
 				CFDictionarySetValue(additionalMetadata, key, value);
 		}
 		else if(TagLib::APE::Item::Binary == item.type()) {
-			SFB::CFString key(CFStringCreateWithCString(kCFAllocatorDefault, item.key().toCString(true), kCFStringEncodingUTF8));
+			SFB::CFString key(item.key().toCString(true), kCFStringEncodingUTF8);
 
 			// From http://www.hydrogenaudio.org/forums/index.php?showtopic=40603&view=findpost&p=504669
 			/*
@@ -160,8 +160,8 @@ bool SFB::Audio::AddAPETagToDictionary(CFMutableDictionaryRef dictionary, std::v
 				auto binaryData = item.binaryData();
 				size_t pos = binaryData.find('\0');
 				if(TagLib::ByteVector::npos() != pos && 3 < binaryData.size()) {
-					SFB::CFData data(CFDataCreate(kCFAllocatorDefault, (const UInt8 *)binaryData.mid(pos + 1).data(), (CFIndex)(binaryData.size() - pos - 1)));
-					SFB::CFString description(CFStringCreateWithCString(kCFAllocatorDefault, TagLib::String(binaryData.mid(0, pos), TagLib::String::UTF8).toCString(true), kCFStringEncodingUTF8));
+					SFB::CFData data((const UInt8 *)binaryData.mid(pos + 1).data(), (CFIndex)(binaryData.size() - pos - 1));
+					SFB::CFString description(TagLib::String(binaryData.mid(0, pos), TagLib::String::UTF8).toCString(true), kCFStringEncodingUTF8);
 
 					attachedPictures.push_back(std::make_shared<AttachedPicture>(data, kCFCompareEqualTo == CFStringCompare(key, CFSTR("Cover Art (Front)"), kCFCompareCaseInsensitive) ? AttachedPicture::Type::FrontCover : AttachedPicture::Type::BackCover, description));
 				}

--- a/Metadata/AddID3v2TagToDictionary.cpp
+++ b/Metadata/AddID3v2TagToDictionary.cpp
@@ -201,7 +201,7 @@ bool SFB::Audio::AddID3v2TagToDictionary(CFMutableDictionaryRef dictionary, std:
 	if(!trackGainFrame)
 		trackGainFrame = TagLib::ID3v2::UserTextIdentificationFrame::find(const_cast<TagLib::ID3v2::Tag *>(tag), "replaygain_track_gain");
 	if(trackGainFrame) {
-		SFB::CFString str(CFStringCreateWithCString(kCFAllocatorDefault, trackGainFrame->fieldList().back().toCString(true), kCFStringEncodingUTF8));
+		SFB::CFString str(trackGainFrame->fieldList().back().toCString(true), kCFStringEncodingUTF8);
 		double num = CFStringGetDoubleValue(str);
 
 		AddDoubleToDictionary(dictionary, Metadata::kTrackGainKey, num);
@@ -213,7 +213,7 @@ bool SFB::Audio::AddID3v2TagToDictionary(CFMutableDictionaryRef dictionary, std:
 	if(!trackPeakFrame)
 		trackPeakFrame = TagLib::ID3v2::UserTextIdentificationFrame::find(const_cast<TagLib::ID3v2::Tag *>(tag), "replaygain_track_peak");
 	if(trackPeakFrame) {
-		SFB::CFString str(CFStringCreateWithCString(kCFAllocatorDefault, trackPeakFrame->fieldList().back().toCString(true), kCFStringEncodingUTF8));
+		SFB::CFString str(trackPeakFrame->fieldList().back().toCString(true), kCFStringEncodingUTF8);
 		double num = CFStringGetDoubleValue(str);
 
 		AddDoubleToDictionary(dictionary, Metadata::kTrackPeakKey, num);
@@ -222,7 +222,7 @@ bool SFB::Audio::AddID3v2TagToDictionary(CFMutableDictionaryRef dictionary, std:
 	if(!albumGainFrame)
 		albumGainFrame = TagLib::ID3v2::UserTextIdentificationFrame::find(const_cast<TagLib::ID3v2::Tag *>(tag), "replaygain_album_gain");
 	if(albumGainFrame) {
-		SFB::CFString str(CFStringCreateWithCString(kCFAllocatorDefault, albumGainFrame->fieldList().back().toCString(true), kCFStringEncodingUTF8));
+		SFB::CFString str(albumGainFrame->fieldList().back().toCString(true), kCFStringEncodingUTF8);
 		double num = CFStringGetDoubleValue(str);
 
 		AddDoubleToDictionary(dictionary, Metadata::kAlbumGainKey, num);
@@ -234,7 +234,7 @@ bool SFB::Audio::AddID3v2TagToDictionary(CFMutableDictionaryRef dictionary, std:
 	if(!albumPeakFrame)
 		albumPeakFrame = TagLib::ID3v2::UserTextIdentificationFrame::find(const_cast<TagLib::ID3v2::Tag *>(tag), "replaygain_album_peak");
 	if(albumPeakFrame) {
-		SFB::CFString str(CFStringCreateWithCString(kCFAllocatorDefault, albumPeakFrame->fieldList().back().toCString(true), kCFStringEncodingUTF8));
+		SFB::CFString str(albumPeakFrame->fieldList().back().toCString(true), kCFStringEncodingUTF8);
 		double num = CFStringGetDoubleValue(str);
 
 		AddDoubleToDictionary(dictionary, Metadata::kAlbumPeakKey, num);
@@ -299,11 +299,11 @@ bool SFB::Audio::AddID3v2TagToDictionary(CFMutableDictionaryRef dictionary, std:
 	for(auto it : tag->frameListMap()["APIC"]) {
 		TagLib::ID3v2::AttachedPictureFrame *frame = dynamic_cast<TagLib::ID3v2::AttachedPictureFrame *>(it);
 		if(frame) {
-			SFB::CFData data(CFDataCreate(kCFAllocatorDefault, (const UInt8 *)frame->picture().data(), (CFIndex)frame->picture().size()));
+			SFB::CFData data((const UInt8 *)frame->picture().data(), (CFIndex)frame->picture().size());
 			
 			SFB::CFString description;
 			if(!frame->description().isEmpty())
-				description = CFString(CFStringCreateWithCString(kCFAllocatorDefault, frame->description().toCString(true), kCFStringEncodingUTF8));
+				description = CFString(frame->description().toCString(true), kCFStringEncodingUTF8);
 			
 			attachedPictures.push_back(std::make_shared<AttachedPicture>(data, (AttachedPicture::Type)frame->type(), description));
 		}

--- a/Metadata/AddXiphCommentToDictionary.cpp
+++ b/Metadata/AddXiphCommentToDictionary.cpp
@@ -39,14 +39,14 @@ bool SFB::Audio::AddXiphCommentToDictionary(CFMutableDictionaryRef dictionary, s
 	if(nullptr == dictionary || nullptr == tag)
 		return false;
 
-	SFB::CFMutableDictionary additionalMetadata(CFDictionaryCreateMutable(kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+	SFB::CFMutableDictionary additionalMetadata(0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
 
 	for(auto it : tag->fieldListMap()) {
 		// According to the Xiph comment specification keys should only contain a limited subset of ASCII, but UTF-8 is a safer choice
-		SFB::CFString key(CFStringCreateWithCString(kCFAllocatorDefault, it.first.toCString(true), kCFStringEncodingUTF8));
+		SFB::CFString key(it.first.toCString(true), kCFStringEncodingUTF8);
 		
 		// Vorbis allows multiple comments with the same key, but this isn't supported by AudioMetadata
-		SFB::CFString value(CFStringCreateWithCString(kCFAllocatorDefault, it.second.front().toCString(true), kCFStringEncodingUTF8));
+		SFB::CFString value(it.second.front().toCString(true), kCFStringEncodingUTF8);
 		
 		if(kCFCompareEqualTo == CFStringCompare(key, CFSTR("ALBUM"), kCFCompareCaseInsensitive))
 			CFDictionarySetValue(dictionary, Metadata::kAlbumTitleKey, value);
@@ -122,11 +122,11 @@ bool SFB::Audio::AddXiphCommentToDictionary(CFMutableDictionaryRef dictionary, s
 				TagLib::FLAC::Picture picture;
 				picture.parse(decodedBlock);
 				
-				SFB::CFData data(CFDataCreate(kCFAllocatorDefault, (const UInt8 *)picture.data().data(), (CFIndex)picture.data().size()));
+				SFB::CFData data((const UInt8 *)picture.data().data(), (CFIndex)picture.data().size());
 
 				SFB::CFString description;
 				if(!picture.description().isEmpty())
-					description = SFB::CFString(CFStringCreateWithCString(kCFAllocatorDefault, picture.description().toCString(true), kCFStringEncodingUTF8));
+					description = SFB::CFString(picture.description().toCString(true), kCFStringEncodingUTF8);
 
 				attachedPictures.push_back(std::make_shared<AttachedPicture>(data, (AttachedPicture::Type)picture.type(), description));
 			}

--- a/Metadata/AttachedPicture.cpp
+++ b/Metadata/AttachedPicture.cpp
@@ -37,11 +37,8 @@ const CFStringRef SFB::Audio::AttachedPicture::kDescriptionKey			= CFSTR("Pictur
 const CFStringRef SFB::Audio::AttachedPicture::kDataKey					= CFSTR("Picture Data");
 
 SFB::Audio::AttachedPicture::AttachedPicture(CFDataRef data, AttachedPicture::Type type, CFStringRef description)
-	: mState(ChangeState::Saved)
+	: mMetadata(0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks), mChangedMetadata(0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks), mState(ChangeState::Saved)
 {
-	mMetadata = CFDictionaryCreateMutable(kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
-	mChangedMetadata = CFDictionaryCreateMutable(kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
-
 	if(data)
 		CFDictionarySetValue(mMetadata, kDataKey, data);
 
@@ -102,7 +99,7 @@ SFB::Audio::AttachedPicture::Type SFB::Audio::AttachedPicture::GetType() const
 
 void SFB::Audio::AttachedPicture::SetType(Type type)
 {
-	SFB::CFNumber wrapper(CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &type));
+	SFB::CFNumber wrapper(kCFNumberIntType, &type);
 	SetValue(kTypeKey, wrapper);
 }
 

--- a/Metadata/AudioMetadata.cpp
+++ b/Metadata/AudioMetadata.cpp
@@ -202,11 +202,8 @@ SFB::Audio::Metadata::unique_ptr SFB::Audio::Metadata::CreateMetadataForURL(CFUR
 #pragma mark Creation and Destruction
 
 SFB::Audio::Metadata::Metadata()
-	: mURL(nullptr)
-{	
-	mMetadata			= CFDictionaryCreateMutable(kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
-	mChangedMetadata	= CFDictionaryCreateMutable(kCFAllocatorDefault,  0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
-}
+	: mURL(nullptr), mMetadata(0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks), mChangedMetadata(0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks)
+{}
 
 SFB::Audio::Metadata::Metadata(CFURLRef url)
 	: Metadata()
@@ -256,7 +253,7 @@ CFDictionaryRef SFB::Audio::Metadata::CreateDictionaryRepresentation() const
 	free(keys), keys = nullptr;
 	free(values), values = nullptr;
 
-	CFMutableArray pictureArray(CFArrayCreateMutable(kCFAllocatorDefault, 0, &kCFTypeArrayCallBacks));
+	CFMutableArray pictureArray(0, &kCFTypeArrayCallBacks);
 
 	for(auto picture : GetAttachedPictures()) {
 		CFDictionary pictureRepresentation(picture->CreateDictionaryRepresentation());

--- a/Metadata/CFDictionaryUtilities.cpp
+++ b/Metadata/CFDictionaryUtilities.cpp
@@ -34,7 +34,7 @@ void SFB::AddIntToDictionary(CFMutableDictionaryRef d, CFStringRef key, int valu
 	if(nullptr == d || nullptr == key)
 		return;
 	
-	SFB::CFNumber num(CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &value));
+	SFB::CFNumber num(kCFNumberIntType, &value);
 	if(num)
 		CFDictionarySetValue(d, key, num);
 }
@@ -44,7 +44,7 @@ void SFB::AddIntToDictionaryAsString(CFMutableDictionaryRef d, CFStringRef key, 
 	if(nullptr == d || nullptr == key)
 		return;
 
-	SFB::CFString str(CFStringCreateWithFormat(kCFAllocatorDefault, nullptr, CFSTR("%d"), value));
+	SFB::CFString str(nullptr, CFSTR("%d"), value);
 	if(str)
 		CFDictionarySetValue(d, key, str);
 }
@@ -54,7 +54,7 @@ void SFB::AddLongLongToDictionary(CFMutableDictionaryRef d, CFStringRef key, lon
 	if(nullptr == d || nullptr == key)
 		return;
 
-	SFB::CFNumber num(CFNumberCreate(kCFAllocatorDefault, kCFNumberLongLongType, &value));
+	SFB::CFNumber num(kCFNumberLongLongType, &value);
 	if(num)
 		CFDictionarySetValue(d, key, num);
 }
@@ -64,7 +64,7 @@ void SFB::AddFloatToDictionary(CFMutableDictionaryRef d, CFStringRef key, float 
 	if(nullptr == d || nullptr == key)
 		return;
 
-	SFB::CFNumber num(CFNumberCreate(kCFAllocatorDefault, kCFNumberFloatType, &value));
+	SFB::CFNumber num(kCFNumberFloatType, &value);
 	if(num)
 		CFDictionarySetValue(d, key, num);
 }
@@ -74,7 +74,7 @@ void SFB::AddDoubleToDictionary(CFMutableDictionaryRef d, CFStringRef key, doubl
 	if(nullptr == d || nullptr == key)
 		return;
 	
-	SFB::CFNumber num(CFNumberCreate(kCFAllocatorDefault, kCFNumberDoubleType, &value));
+	SFB::CFNumber num(kCFNumberDoubleType, &value);
 	if(num)
 		CFDictionarySetValue(d, key, num);
 }

--- a/Metadata/FLACMetadata.cpp
+++ b/Metadata/FLACMetadata.cpp
@@ -164,11 +164,11 @@ bool SFB::Audio::FLACMetadata::_ReadMetadata(CFErrorRef *error)
 
 	// Add album art
 	for(auto iter : file.pictureList()) {
-		SFB::CFData data(CFDataCreate(kCFAllocatorDefault, (const UInt8 *)iter->data().data(), (CFIndex)iter->data().size()));
+		SFB::CFData data((const UInt8 *)iter->data().data(), (CFIndex)iter->data().size());
 
 		SFB::CFString description;
 		if(!iter->description().isEmpty())
-			description = CFString(CFStringCreateWithCString(kCFAllocatorDefault, iter->description().toCString(true), kCFStringEncodingUTF8));
+			description = CFString(iter->description().toCString(true), kCFStringEncodingUTF8);
 
 		mPictures.push_back(std::make_shared<AttachedPicture>(data, (AttachedPicture::Type)iter->type(), description));
 	}

--- a/Metadata/MP4Metadata.cpp
+++ b/Metadata/MP4Metadata.cpp
@@ -148,19 +148,19 @@ bool SFB::Audio::MP4Metadata::_ReadMetadata(CFErrorRef *error)
 		MP4Duration mp4Duration = MP4GetTrackDuration(file, trackID);
 		uint32_t mp4TimeScale = MP4GetTrackTimeScale(file, trackID);
 		
-		SFB::CFNumber totalFrames(CFNumberCreate(kCFAllocatorDefault, kCFNumberLongLongType, &mp4Duration));
+		SFB::CFNumber totalFrames(kCFNumberLongLongType, &mp4Duration);
 		CFDictionarySetValue(mMetadata, kTotalFramesKey, totalFrames);
 
-		SFB::CFNumber sampleRate(CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &mp4TimeScale));
+		SFB::CFNumber sampleRate(kCFNumberIntType, &mp4TimeScale);
 		CFDictionarySetValue(mMetadata, kSampleRateKey, sampleRate);
 
 		double length = (double)mp4Duration / (double)mp4TimeScale;
-		SFB::CFNumber duration(CFNumberCreate(kCFAllocatorDefault, kCFNumberDoubleType, &length));
+		SFB::CFNumber duration(kCFNumberDoubleType, &length);
 		CFDictionarySetValue(mMetadata, kDurationKey, duration);
 
 		// "mdia.minf.stbl.stsd.*[0].channels"
 		int channels = MP4GetTrackAudioChannels(file, trackID);
-		SFB::CFNumber channelsPerFrame(CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &channels));
+		SFB::CFNumber channelsPerFrame(kCFNumberIntType, &channels);
 		CFDictionaryAddValue(mMetadata, kChannelsPerFrameKey, channelsPerFrame);
 
 		// ALAC files
@@ -174,21 +174,21 @@ bool SFB::Audio::MP4Metadata::_ReadMetadata(CFErrorRef *error)
 				// The ALAC magic cookie seems to have the following layout (28 bytes, BE):
 				// Byte 10: Sample size
 				// Bytes 25-28: Sample rate
-				SFB::CFNumber bitsPerChannel(CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt8Type, decoderConfig + 9));
+				SFB::CFNumber bitsPerChannel(kCFNumberSInt8Type, decoderConfig + 9);
 				CFDictionaryAddValue(mMetadata, kBitsPerChannelKey, bitsPerChannel);
 
 				double losslessBitrate = (double)(mp4TimeScale * (unsigned int)channels * decoderConfig[9]) / 1000.0;
-				SFB::CFNumber bitrate(CFNumberCreate(kCFAllocatorDefault, kCFNumberDoubleType, &losslessBitrate));
+				SFB::CFNumber bitrate(kCFNumberDoubleType, &losslessBitrate);
 				CFDictionarySetValue(mMetadata, kBitrateKey, bitrate);
 
 				free(decoderConfig), decoderConfig = nullptr;
 			}			
 			else if(MP4GetTrackIntegerProperty(file, trackID, "mdia.minf.stbl.stsd.alac.sampleSize", &sampleSize)) {
-				SFB::CFNumber bitsPerChannel(CFNumberCreate(kCFAllocatorDefault, kCFNumberLongLongType, &sampleSize));
+				SFB::CFNumber bitsPerChannel(kCFNumberLongLongType, &sampleSize);
 				CFDictionaryAddValue(mMetadata, kBitsPerChannelKey, bitsPerChannel);
 
 				double losslessBitrate = (double)(mp4TimeScale * (unsigned int)channels * sampleSize) / 1000.0;
-				SFB::CFNumber bitrate(CFNumberCreate(kCFAllocatorDefault, kCFNumberDoubleType, &losslessBitrate));
+				SFB::CFNumber bitrate(kCFNumberDoubleType, &losslessBitrate);
 				CFDictionarySetValue(mMetadata, kBitrateKey, bitrate);
 			}
 		}
@@ -199,7 +199,7 @@ bool SFB::Audio::MP4Metadata::_ReadMetadata(CFErrorRef *error)
 
 			// "mdia.minf.stbl.stsd.*.esds.decConfigDescr.avgBitrate"
 			uint32_t trackBitrate = MP4GetTrackBitRate(file, trackID) / 1000;
-			SFB::CFNumber bitrate(CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &trackBitrate));
+			SFB::CFNumber bitrate(kCFNumberIntType, &trackBitrate);
 			CFDictionaryAddValue(mMetadata, kBitrateKey, bitrate);
 
 		}
@@ -235,56 +235,56 @@ bool SFB::Audio::MP4Metadata::_ReadMetadata(CFErrorRef *error)
 	
 	// Album title
 	if(tags->album) {
-		SFB::CFString str(CFStringCreateWithCString(kCFAllocatorDefault, tags->album, kCFStringEncodingUTF8));
+		SFB::CFString str(tags->album, kCFStringEncodingUTF8);
 		if(str)
 			CFDictionarySetValue(mMetadata, kAlbumTitleKey, str);
 	}
 	
 	// Artist
 	if(tags->artist) {
-		SFB::CFString str(CFStringCreateWithCString(kCFAllocatorDefault, tags->artist, kCFStringEncodingUTF8));
+		SFB::CFString str(tags->artist, kCFStringEncodingUTF8);
 		if(str)
 			CFDictionarySetValue(mMetadata, kArtistKey, str);
 	}
 	
 	// Album Artist
 	if(tags->albumArtist) {
-		SFB::CFString str(CFStringCreateWithCString(kCFAllocatorDefault, tags->albumArtist, kCFStringEncodingUTF8));
+		SFB::CFString str(tags->albumArtist, kCFStringEncodingUTF8);
 		if(str)
 			CFDictionarySetValue(mMetadata, kAlbumArtistKey, str);
 	}
 	
 	// Genre
 	if(tags->genre) {
-		SFB::CFString str(CFStringCreateWithCString(kCFAllocatorDefault, tags->genre, kCFStringEncodingUTF8));
+		SFB::CFString str(tags->genre, kCFStringEncodingUTF8);
 		if(str)
 			CFDictionarySetValue(mMetadata, kGenreKey, str);
 	}
 	
 	// Release date
 	if(tags->releaseDate) {
-		SFB::CFString str(CFStringCreateWithCString(kCFAllocatorDefault, tags->releaseDate, kCFStringEncodingUTF8));
+		SFB::CFString str(tags->releaseDate, kCFStringEncodingUTF8);
 		if(str)
 			CFDictionarySetValue(mMetadata, kReleaseDateKey, str);
 	}
 	
 	// Composer
 	if(tags->composer) {
-		SFB::CFString str(CFStringCreateWithCString(kCFAllocatorDefault, tags->composer, kCFStringEncodingUTF8));
+		SFB::CFString str(tags->composer, kCFStringEncodingUTF8);
 		if(str)
 			CFDictionarySetValue(mMetadata, kComposerKey, str);
 	}
 	
 	// Comment
 	if(tags->comments) {
-		SFB::CFString str(CFStringCreateWithCString(kCFAllocatorDefault, tags->comments, kCFStringEncodingUTF8));
+		SFB::CFString str(tags->comments, kCFStringEncodingUTF8);
 		if(str)
 			CFDictionarySetValue(mMetadata, kCommentKey, str);
 	}
 	
 	// Track title
 	if(tags->name) {
-		SFB::CFString str(CFStringCreateWithCString(kCFAllocatorDefault, tags->name, kCFStringEncodingUTF8));
+		SFB::CFString str(tags->name, kCFStringEncodingUTF8);
 		if(str)
 			CFDictionarySetValue(mMetadata, kTitleKey, str);
 	}
@@ -292,12 +292,12 @@ bool SFB::Audio::MP4Metadata::_ReadMetadata(CFErrorRef *error)
 	// Track number
 	if(tags->track) {
 		if(tags->track->index) {
-			SFB::CFNumber num(CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt16Type, &tags->track->index));
+			SFB::CFNumber num(kCFNumberSInt16Type, &tags->track->index);
 			CFDictionarySetValue(mMetadata, kTrackNumberKey, num);
 		}
 		
 		if(tags->track->total) {
-			SFB::CFNumber num(CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt16Type, &tags->track->total));
+			SFB::CFNumber num(kCFNumberSInt16Type, &tags->track->total);
 			CFDictionarySetValue(mMetadata, kTrackTotalKey, num);
 		}
 	}
@@ -305,12 +305,12 @@ bool SFB::Audio::MP4Metadata::_ReadMetadata(CFErrorRef *error)
 	// Disc number
 	if(tags->disk) {
 		if(tags->disk->index) {
-			SFB::CFNumber num(CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt16Type, &tags->disk->index));
+			SFB::CFNumber num(kCFNumberSInt16Type, &tags->disk->index);
 			CFDictionarySetValue(mMetadata, kDiscNumberKey, num);
 		}
 		
 		if(tags->disk->total) {
-			SFB::CFNumber num(CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt16Type, &tags->disk->total));
+			SFB::CFNumber num(kCFNumberSInt16Type, &tags->disk->total);
 			CFDictionarySetValue(mMetadata, kDiscTotalKey, num);
 		}
 	}
@@ -321,49 +321,49 @@ bool SFB::Audio::MP4Metadata::_ReadMetadata(CFErrorRef *error)
 	
 	// BPM
 	if(tags->tempo) {
-		SFB::CFNumber num(CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt16Type, &tags->tempo));
+		SFB::CFNumber num(kCFNumberSInt16Type, &tags->tempo);
 		CFDictionarySetValue(mMetadata, kBPMKey, num);
 	}
 	
 	// Lyrics
 	if(tags->lyrics) {
-		SFB::CFString str(CFStringCreateWithCString(kCFAllocatorDefault, tags->lyrics, kCFStringEncodingUTF8));
+		SFB::CFString str(tags->lyrics, kCFStringEncodingUTF8);
 		if(str)
 			CFDictionarySetValue(mMetadata, kLyricsKey, str);
 	}
 
 	if(tags->sortName) {
-		SFB::CFString str(CFStringCreateWithCString(kCFAllocatorDefault, tags->sortName, kCFStringEncodingUTF8));
+		SFB::CFString str(tags->sortName, kCFStringEncodingUTF8);
 		if(str)
 			CFDictionarySetValue(mMetadata, kTitleSortOrderKey, str);
 	}
 
 	if(tags->sortAlbum) {
-		SFB::CFString str(CFStringCreateWithCString(kCFAllocatorDefault, tags->sortAlbum, kCFStringEncodingUTF8));
+		SFB::CFString str(tags->sortAlbum, kCFStringEncodingUTF8);
 		if(str)
 			CFDictionarySetValue(mMetadata, kAlbumTitleSortOrderKey, str);
 	}
 
 	if(tags->sortArtist) {
-		SFB::CFString str(CFStringCreateWithCString(kCFAllocatorDefault, tags->sortArtist, kCFStringEncodingUTF8));
+		SFB::CFString str(tags->sortArtist, kCFStringEncodingUTF8);
 		if(str)
 			CFDictionarySetValue(mMetadata, kArtistSortOrderKey, str);
 	}
 
 	if(tags->sortAlbumArtist) {
-		SFB::CFString str(CFStringCreateWithCString(kCFAllocatorDefault, tags->sortAlbumArtist, kCFStringEncodingUTF8));
+		SFB::CFString str(tags->sortAlbumArtist, kCFStringEncodingUTF8);
 		if(str)
 			CFDictionarySetValue(mMetadata, kAlbumArtistSortOrderKey, str);
 	}
 
 	if(tags->sortComposer) {
-		SFB::CFString str(CFStringCreateWithCString(kCFAllocatorDefault, tags->sortComposer, kCFStringEncodingUTF8));
+		SFB::CFString str(tags->sortComposer, kCFStringEncodingUTF8);
 		if(str)
 			CFDictionarySetValue(mMetadata, kComposerSortOrderKey, str);
 	}
 
 	if(tags->grouping) {
-		SFB::CFString str(CFStringCreateWithCString(kCFAllocatorDefault, tags->grouping, kCFStringEncodingUTF8));
+		SFB::CFString str(tags->grouping, kCFStringEncodingUTF8);
 		if(str)
 			CFDictionarySetValue(mMetadata, kGroupingKey, str);
 	}
@@ -371,7 +371,7 @@ bool SFB::Audio::MP4Metadata::_ReadMetadata(CFErrorRef *error)
 	// Album art
 	if(tags->artworkCount) {
 		for(uint32_t i = 0; i < tags->artworkCount; ++i) {
-			SFB::CFData data(CFDataCreate(kCFAllocatorDefault, (const UInt8 *)tags->artwork[i].data, tags->artwork[i].size));
+			SFB::CFData data((const UInt8 *)tags->artwork[i].data, tags->artwork[i].size);
 
 			mPictures.push_back(std::make_shared<AttachedPicture>(data));
 		}
@@ -381,7 +381,7 @@ bool SFB::Audio::MP4Metadata::_ReadMetadata(CFErrorRef *error)
 	MP4ItmfItemList *items = MP4ItmfGetItemsByMeaning(file, "com.apple.iTunes", "MusicBrainz Album Id");
 	if(nullptr != items) {
 		if(1 <= items->size && 1 <= items->elements[0].dataList.size) {
-			SFB::CFString releaseID(CFStringCreateWithCString(kCFAllocatorDefault, (const char *)items->elements[0].dataList.elements[0].value, kCFStringEncodingUTF8));
+			SFB::CFString releaseID((const char *)items->elements[0].dataList.elements[0].value, kCFStringEncodingUTF8);
 			CFDictionaryAddValue(mMetadata, kMusicBrainzReleaseIDKey, releaseID);
 		}
 
@@ -391,7 +391,7 @@ bool SFB::Audio::MP4Metadata::_ReadMetadata(CFErrorRef *error)
 	items = MP4ItmfGetItemsByMeaning(file, "com.apple.iTunes", "MusicBrainz Track Id");
 	if(nullptr != items) {
 		if(1 <= items->size && 1 <= items->elements[0].dataList.size) {
-			SFB::CFString recordingID(CFStringCreateWithCString(kCFAllocatorDefault, (const char *)items->elements[0].dataList.elements[0].value, kCFStringEncodingUTF8));
+			SFB::CFString recordingID((const char *)items->elements[0].dataList.elements[0].value, kCFStringEncodingUTF8);
 			CFDictionaryAddValue(mMetadata, kMusicBrainzRecordingIDKey, recordingID);
 		}
 
@@ -405,7 +405,7 @@ bool SFB::Audio::MP4Metadata::_ReadMetadata(CFErrorRef *error)
 	if(nullptr != items) {
 		float referenceLoudnessValue;
 		if(1 <= items->size && 1 <= items->elements[0].dataList.size && sscanf((const char *)items->elements[0].dataList.elements[0].value, "%f", &referenceLoudnessValue)) {
-			SFB::CFNumber referenceLoudness(CFNumberCreate(kCFAllocatorDefault, kCFNumberFloatType, &referenceLoudnessValue));
+			SFB::CFNumber referenceLoudness(kCFNumberFloatType, &referenceLoudnessValue);
 			CFDictionaryAddValue(mMetadata, kReferenceLoudnessKey, referenceLoudness);
 		}
 		
@@ -417,7 +417,7 @@ bool SFB::Audio::MP4Metadata::_ReadMetadata(CFErrorRef *error)
 	if(nullptr != items) {
 		float trackGainValue;
 		if(1 <= items->size && 1 <= items->elements[0].dataList.size && sscanf((const char *)items->elements[0].dataList.elements[0].value, "%f", &trackGainValue)) {
-			SFB::CFNumber trackGain(CFNumberCreate(kCFAllocatorDefault, kCFNumberFloatType, &trackGainValue));
+			SFB::CFNumber trackGain(kCFNumberFloatType, &trackGainValue);
 			CFDictionaryAddValue(mMetadata, kTrackGainKey, trackGain);
 		}
 		
@@ -429,7 +429,7 @@ bool SFB::Audio::MP4Metadata::_ReadMetadata(CFErrorRef *error)
 	if(nullptr != items) {
 		float trackPeakValue;
 		if(1 <= items->size && 1 <= items->elements[0].dataList.size && sscanf((const char *)items->elements[0].dataList.elements[0].value, "%f", &trackPeakValue)) {
-			SFB::CFNumber trackPeak(CFNumberCreate(kCFAllocatorDefault, kCFNumberFloatType, &trackPeakValue));
+			SFB::CFNumber trackPeak(kCFNumberFloatType, &trackPeakValue);
 			CFDictionaryAddValue(mMetadata, kTrackPeakKey, trackPeak);
 		}
 		
@@ -441,7 +441,7 @@ bool SFB::Audio::MP4Metadata::_ReadMetadata(CFErrorRef *error)
 	if(nullptr != items) {
 		float albumGainValue;
 		if(1 <= items->size && 1 <= items->elements[0].dataList.size && sscanf((const char *)items->elements[0].dataList.elements[0].value, "%f", &albumGainValue)) {
-			SFB::CFNumber albumGain(CFNumberCreate(kCFAllocatorDefault, kCFNumberFloatType, &albumGainValue));
+			SFB::CFNumber albumGain(kCFNumberFloatType, &albumGainValue);
 			CFDictionaryAddValue(mMetadata, kAlbumGainKey, albumGain);
 		}
 		
@@ -453,7 +453,7 @@ bool SFB::Audio::MP4Metadata::_ReadMetadata(CFErrorRef *error)
 	if(nullptr != items) {
 		float albumPeakValue;
 		if(1 <= items->size && 1 <= items->elements[0].dataList.size && sscanf((const char *)items->elements[0].dataList.elements[0].value, "%f", &albumPeakValue)) {
-			SFB::CFNumber albumPeak(CFNumberCreate(kCFAllocatorDefault, kCFNumberFloatType, &albumPeakValue));
+			SFB::CFNumber albumPeak(kCFNumberFloatType, &albumPeakValue);
 			CFDictionaryAddValue(mMetadata, kAlbumPeakKey, albumPeak);
 		}
 		

--- a/Metadata/SetAPETagFromMetadata.cpp
+++ b/Metadata/SetAPETagFromMetadata.cpp
@@ -64,7 +64,7 @@ namespace {
 
 		SFB::CFString numberString;
 		if(nullptr != value)
-			numberString = SFB::CFString(CFSTR("%@"), value);
+			numberString = SFB::CFString(nullptr, CFSTR("%@"), value);
 
 		bool result = SetAPETag(tag, key, numberString);
 

--- a/Metadata/SetAPETagFromMetadata.cpp
+++ b/Metadata/SetAPETagFromMetadata.cpp
@@ -64,7 +64,7 @@ namespace {
 
 		SFB::CFString numberString;
 		if(nullptr != value)
-			numberString = SFB::CFString(CFStringCreateWithFormat(kCFAllocatorDefault, nullptr, CFSTR("%@"), value));
+			numberString = SFB::CFString(CFSTR("%@"), value);
 
 		bool result = SetAPETag(tag, key, numberString);
 
@@ -95,7 +95,7 @@ namespace {
 			if(!CFNumberGetValue(value, kCFNumberDoubleType, &f))
 				LOGGER_INFO("org.sbooth.AudioEngine", "CFNumberGetValue returned an approximation");
 
-			numberString = SFB::CFString(CFStringCreateWithFormat(kCFAllocatorDefault, nullptr, nullptr == format ? CFSTR("%f") : format, f));
+			numberString = SFB::CFString(nullptr, format ?: CFSTR("%f"), f);
 		}
 
 		bool result = SetAPETag(tag, key, numberString);

--- a/Metadata/SetID3v2TagFromMetadata.cpp
+++ b/Metadata/SetID3v2TagFromMetadata.cpp
@@ -55,7 +55,7 @@ namespace {
 				double d;
 				CFNumberGetValue(value, type, &d);
 
-				return CFStringCreateWithFormat(kCFAllocatorDefault, nullptr, nullptr == format ? CFSTR("%f") : format, d);
+				return CFStringCreateWithFormat(kCFAllocatorDefault, nullptr, format ?: CFSTR("%f"), d);
 			}
 
 				// Everything else
@@ -140,7 +140,7 @@ bool SFB::Audio::SetID3v2TagFromMetadata(const Metadata& metadata, TagLib::ID3v2
 	// BPM
 	tag->removeFrames("TBPM");
 	if(metadata.GetBPM()) {
-		SFB::CFString str(CFStringCreateWithFormat(kCFAllocatorDefault, nullptr, CFSTR("%@"), metadata.GetBPM()));
+		SFB::CFString str(nullptr, CFSTR("%@"), metadata.GetBPM());
 
 		auto frame = new TagLib::ID3v2::TextIdentificationFrame("TBPM", TagLib::String::Latin1);
 		frame->setText(TagLib::StringFromCFString(str));
@@ -168,21 +168,21 @@ bool SFB::Audio::SetID3v2TagFromMetadata(const Metadata& metadata, TagLib::ID3v2
 	CFNumberRef trackNumber	= metadata.GetTrackNumber();
 	CFNumberRef trackTotal	= metadata.GetTrackTotal();
 	if(trackNumber && trackTotal) {
-		SFB::CFString str(CFStringCreateWithFormat(kCFAllocatorDefault, nullptr, CFSTR("%@/%@"), trackNumber, trackTotal));
+		SFB::CFString str(nullptr, CFSTR("%@/%@"), trackNumber, trackTotal);
 
 		auto frame = new TagLib::ID3v2::TextIdentificationFrame("TRCK", TagLib::String::Latin1);
 		frame->setText(TagLib::StringFromCFString(str));
 		tag->addFrame(frame);
 	}
 	else if(trackNumber) {		
-		SFB::CFString str(CFStringCreateWithFormat(kCFAllocatorDefault, nullptr, CFSTR("%@"), trackNumber));
+		SFB::CFString str(nullptr, CFSTR("%@"), trackNumber);
 		
 		auto frame = new TagLib::ID3v2::TextIdentificationFrame("TRCK", TagLib::String::Latin1);
 		frame->setText(TagLib::StringFromCFString(str));
 		tag->addFrame(frame);
 	}
 	else if(trackTotal) {		
-		SFB::CFString str(CFStringCreateWithFormat(kCFAllocatorDefault, nullptr, CFSTR("/%@"), trackTotal));
+		SFB::CFString str(nullptr, CFSTR("/%@"), trackTotal);
 		
 		auto frame = new TagLib::ID3v2::TextIdentificationFrame("TRCK", TagLib::String::Latin1);
 		frame->setText(TagLib::StringFromCFString(str));
@@ -203,21 +203,21 @@ bool SFB::Audio::SetID3v2TagFromMetadata(const Metadata& metadata, TagLib::ID3v2
 	CFNumberRef discNumber	= metadata.GetDiscNumber();
 	CFNumberRef discTotal	= metadata.GetDiscTotal();
 	if(discNumber && discTotal) {
-		SFB::CFString str(CFStringCreateWithFormat(kCFAllocatorDefault, nullptr, CFSTR("%@/%@"), discNumber, discTotal));
+		SFB::CFString str(nullptr, CFSTR("%@/%@"), discNumber, discTotal);
 		
 		auto frame = new TagLib::ID3v2::TextIdentificationFrame("TPOS", TagLib::String::Latin1);
 		frame->setText(TagLib::StringFromCFString(str));
 		tag->addFrame(frame);
 	}
 	else if(discNumber) {		
-		SFB::CFString str(CFStringCreateWithFormat(kCFAllocatorDefault, nullptr, CFSTR("%@"), discNumber));
+		SFB::CFString str(nullptr, CFSTR("%@"), discNumber);
 		
 		auto frame = new TagLib::ID3v2::TextIdentificationFrame("TPOS", TagLib::String::Latin1);
 		frame->setText(TagLib::StringFromCFString(str));
 		tag->addFrame(frame);
 	}
 	else if(discTotal) {		
-		SFB::CFString str(CFStringCreateWithFormat(kCFAllocatorDefault, nullptr, CFSTR("/%@"), discTotal));
+		SFB::CFString str(nullptr, CFSTR("/%@"), discTotal);
 		
 		auto frame = new TagLib::ID3v2::TextIdentificationFrame("TPOS", TagLib::String::Latin1);
 		frame->setText(TagLib::StringFromCFString(str));

--- a/Metadata/SetXiphCommentFromMetadata.cpp
+++ b/Metadata/SetXiphCommentFromMetadata.cpp
@@ -64,7 +64,7 @@ namespace {
 
 		SFB::CFString numberString;
 		if(nullptr != value)
-			numberString = SFB::CFString(CFStringCreateWithFormat(kCFAllocatorDefault, nullptr, CFSTR("%@"), value));
+			numberString = SFB::CFString(CFSTR("%@"), value);
 
 		bool result = SetXiphComment(tag, key, numberString);
 
@@ -95,7 +95,7 @@ namespace {
 			if(!CFNumberGetValue(value, kCFNumberDoubleType, &f))
 				LOGGER_INFO("org.sbooth.AudioEngine", "CFNumberGetValue returned an approximation");
 
-			numberString = SFB::CFString(CFStringCreateWithFormat(kCFAllocatorDefault, nullptr, nullptr == format ? CFSTR("%f") : format, f));
+			numberString = SFB::CFString(nullptr, format ?: CFSTR("%f"), f);
 		}
 
 		bool result = SetXiphComment(tag, key, numberString);

--- a/Metadata/SetXiphCommentFromMetadata.cpp
+++ b/Metadata/SetXiphCommentFromMetadata.cpp
@@ -64,7 +64,7 @@ namespace {
 
 		SFB::CFString numberString;
 		if(nullptr != value)
-			numberString = SFB::CFString(CFSTR("%@"), value);
+			numberString = SFB::CFString(nullptr, CFSTR("%@"), value);
 
 		bool result = SetXiphComment(tag, key, numberString);
 

--- a/Metadata/TagLibStringUtilities.cpp
+++ b/Metadata/TagLibStringUtilities.cpp
@@ -62,7 +62,7 @@ void TagLib::AddStringToCFDictionary(CFMutableDictionaryRef d, CFStringRef key, 
 	if(nullptr == d || nullptr == key || value.isEmpty())
 		return;
 
-	SFB::CFString string(CFStringCreateWithCString(kCFAllocatorDefault, value.toCString(true), kCFStringEncodingUTF8));
+	SFB::CFString string(value.toCString(true), kCFStringEncodingUTF8);
 	if(string)
 		CFDictionarySetValue(d, key, string);
 }

--- a/Output/ASIOOutput.cpp
+++ b/Output/ASIOOutput.cpp
@@ -259,7 +259,7 @@ namespace {
 	// Sadly ASIO requires global state
 	static SFB::Audio::ASIOOutput *sOutput	= nullptr;
 	static AsioDriver		*sASIO		= nullptr;
-	static DriverInfo		sDriverInfo	= {{0}};
+	static DriverInfo		sDriverInfo	= {};
 	static ASIOCallbacks	sCallbacks	= {
 		.bufferSwitch			= myASIOBufferSwitch,
 		.sampleRateDidChange	= myASIOSampleRateDidChange,
@@ -273,7 +273,7 @@ namespace {
 	// Backdoor into myASIOBufferSwitchTimeInfo
 	void myASIOBufferSwitch(long doubleBufferIndex, ASIOBool directProcess)
 	{
-		ASIOTime timeInfo = {{0}};
+		ASIOTime timeInfo = {};
 
 		auto result = sASIO->getSamplePosition(&timeInfo.timeInfo.samplePosition, &timeInfo.timeInfo.systemTime);
 		if(ASE_OK == result)
@@ -296,6 +296,9 @@ namespace {
 
 	ASIOTime * myASIOBufferSwitchTimeInfo(ASIOTime *params, long doubleBufferIndex, ASIOBool directProcess)
 	{
+#pragma unused(params)
+#pragma unused(directProcess)
+
 		if(sOutput)
 			sOutput->FillASIOBuffer(doubleBufferIndex);
 		return nullptr;
@@ -332,36 +335,36 @@ CFArrayRef SFB::Audio::ASIOOutput::CreateAvailableDrivers()
 		return nullptr;
 	}
 
-	CFMutableArray driverInfoArray = CFArrayCreateMutable(kCFAllocatorDefault, 0, &kCFTypeArrayCallBacks);
+	CFMutableArray driverInfoArray(0, &kCFTypeArrayCallBacks);
 	if(!driverInfoArray)
 		return nullptr;
 
 	for(unsigned int i = 0; i < count; ++i) {
-		CFMutableDictionary driverDictionary = CFDictionaryCreateMutable(kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+		CFMutableDictionary driverDictionary(0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
 		if(!driverDictionary)
 			continue;
 
-		CFString driverID(CFStringCreateWithCString(kCFAllocatorDefault, buffer[i].Id, kCFStringEncodingASCII));
+		CFString driverID(buffer[i].Id, kCFStringEncodingASCII);
 		CFDictionarySetValue(driverDictionary, kDriverIDKey, driverID);
 
-		CFNumber driverNumber(CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &buffer[i].Number));
+		CFNumber driverNumber(kCFNumberIntType, &buffer[i].Number);
 		CFDictionarySetValue(driverDictionary, kDriverNumberKey, driverNumber);
 
-		CFString driverDisplayName(CFStringCreateWithCString(kCFAllocatorDefault, buffer[i].DisplayName, kCFStringEncodingASCII));
+		CFString driverDisplayName(buffer[i].DisplayName, kCFStringEncodingASCII);
 		CFDictionarySetValue(driverDictionary, kDriverDisplayNameKey, driverDisplayName);
 
-		CFString driverCompany(CFStringCreateWithCString(kCFAllocatorDefault, buffer[i].Company, kCFStringEncodingASCII));
+		CFString driverCompany(buffer[i].Company, kCFStringEncodingASCII);
 		CFDictionarySetValue(driverDictionary, kDriverCompanyKey, driverCompany);
 
-		CFString driverFolder(CFStringCreateWithCString(kCFAllocatorDefault, buffer[i].InstallFolder, kCFStringEncodingASCII));
+		CFString driverFolder(buffer[i].InstallFolder, kCFStringEncodingASCII);
 		CFDictionarySetValue(driverDictionary, kDriverFolderKey, driverFolder);
 
-		CFString driverArchitecture(CFStringCreateWithCString(kCFAllocatorDefault, buffer[i].Architectures, kCFStringEncodingASCII));
+		CFString driverArchitecture(buffer[i].Architectures, kCFStringEncodingASCII);
 		CFDictionarySetValue(driverDictionary, kDriverArchitecturesKey, driverArchitecture);
 
 		char deviceUID [1024];
 		if(buffer[i].ToCString(deviceUID, 1024, '|')) {
-			CFString driverUID(CFStringCreateWithCString(kCFAllocatorDefault, deviceUID, kCFStringEncodingASCII));
+			CFString driverUID(deviceUID, kCFStringEncodingASCII);
 			CFDictionarySetValue(driverDictionary, kDriverUIDKey, driverUID);
 		}
 		else
@@ -691,7 +694,7 @@ bool SFB::Audio::ASIOOutput::_SetupForDecoder(const Decoder& decoder)
 
 
 	// Store the ASIO driver format
-	asioFormat = {0};
+	asioFormat = {};
 	result = sASIO->future(kAsioGetIoFormat, &asioFormat);
 	if(ASE_SUCCESS != result) {
 		LOGGER_ERR("org.sbooth.AudioEngine.Output.ASIO", "Unable to get ASIO format: " << result);
@@ -872,6 +875,9 @@ bool SFB::Audio::ASIOOutput::_SetDeviceUID(CFStringRef deviceUID)
 
 long SFB::Audio::ASIOOutput::HandleASIOMessage(long selector, long value, void *message, double *opt)
 {
+#pragma unused(message)
+#pragma unused(opt)
+
 	LOGGER_INFO("org.sbooth.AudioEngine.Output.ASIO", "HandleASIOMessage: selector = " << selector << ", value = " << value);
 
 	switch(selector) {


### PR DESCRIPTION
Since `CFWrapper(T obj)` is now `explicit` this alleviates some of the ugliness when using `CFWrapper`.