### PR TITLE
Documentation standardization

### DIFF
--- a/Analysis/SFBReplayGainAnalyzer.h
+++ b/Analysis/SFBReplayGainAnalyzer.h
@@ -10,8 +10,10 @@ NS_ASSUME_NONNULL_BEGIN
 typedef NSString * SFBReplayGainAnalyzerKey NS_TYPED_ENUM NS_SWIFT_NAME(ReplayGainAnalyzer.Key);
 
 // Replay gain  dictionary keys
-extern SFBReplayGainAnalyzerKey const SFBReplayGainAnalyzerGainKey;		///< The gain in dB (\c NSNumber)
-extern SFBReplayGainAnalyzerKey const SFBReplayGainAnalyzerPeakKey;		///< The peak value normalized to [-1, 1) (\c NSNumber)
+/// The gain in dB (\c NSNumber)
+extern SFBReplayGainAnalyzerKey const SFBReplayGainAnalyzerGainKey;
+/// The peak value normalized to [-1, 1) (\c NSNumber)
+extern SFBReplayGainAnalyzerKey const SFBReplayGainAnalyzerPeakKey;
 
 
 /// A class that calculates replay gain
@@ -50,8 +52,10 @@ extern NSErrorDomain const SFBReplayGainAnalyzerErrorDomain NS_SWIFT_NAME(Replay
 
 /// Possible \c NSError  error codes used by \c SFBReplayGainAnalyzer
 typedef NS_ERROR_ENUM(SFBReplayGainAnalyzerErrorDomain, SFBReplayGainAnalyzerErrorCode) {
-	SFBReplayGainAnalyzerErrorCodeFileFormatNotSupported		= 0,	///< File format not supported
-	SFBReplayGainAnalyzerErrorCodeInsufficientSamples			= 1,	///< Insufficient samples in file for analysis
+	/// File format not supported
+	SFBReplayGainAnalyzerErrorCodeFileFormatNotSupported		= 0,
+	/// Insufficient samples in file for analysis
+	SFBReplayGainAnalyzerErrorCodeInsufficientSamples			= 1,
 } NS_SWIFT_NAME(ReplayGainAnalyzer.ErrorCode);
 
 NS_ASSUME_NONNULL_END

--- a/Analysis/SFBReplayGainAnalyzer.h
+++ b/Analysis/SFBReplayGainAnalyzer.h
@@ -9,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 typedef NSString * SFBReplayGainAnalyzerKey NS_TYPED_ENUM NS_SWIFT_NAME(ReplayGainAnalyzer.Key);
 
-// Replay gain  dictionary keys
+// Replay gain dictionary keys
 /// The gain in dB (\c NSNumber)
 extern SFBReplayGainAnalyzerKey const SFBReplayGainAnalyzerGainKey;
 /// The peak value normalized to [-1, 1) (\c NSNumber)
@@ -29,7 +29,7 @@ NS_SWIFT_NAME(ReplayGainAnalyzer) @interface SFBReplayGainAnalyzer : NSObject
 /// The returned dictionary will contain the entries returned by \c -albumGainAndPeakSample and the
 /// results of \c -trackGainAndPeakSample keyed by URL
 /// @param urls The URLs to analyze
-/// @param error An optional pointer to an \c NSError  to receive error information
+/// @param error An optional pointer to an \c NSError object to receive error information
 /// @return A dictionary of gain and peak information, or \c nil on error
 + (nullable NSDictionary *)analyzeAlbum:(NSArray<NSURL *> *)urls error:(NSError **)error NS_REFINED_FOR_SWIFT;
 
@@ -38,7 +38,7 @@ NS_SWIFT_NAME(ReplayGainAnalyzer) @interface SFBReplayGainAnalyzer : NSObject
 /// If the URL's sample rate is not natively supported, the replay gain adjustment will be calculated using audio
 /// resampled to an even multiple sample rate
 /// @param url The URL to analyze
-/// @param error An optional pointer to an \c NSError  to receive error information
+/// @param error An optional pointer to an \c NSError object to receive error information
 /// @return A dictionary containing the track gain in dB (\c SFBReplayGainAnalyzerGainKey) and peak sample value normalized to [-1, 1) (\c SFBReplayGainAnalyzerPeakKey), or \c nil on error
 - (nullable NSDictionary<SFBReplayGainAnalyzerKey, NSNumber *> *)analyzeTrack:(NSURL *)url error:(NSError **)error NS_REFINED_FOR_SWIFT;
 
@@ -50,7 +50,7 @@ NS_SWIFT_NAME(ReplayGainAnalyzer) @interface SFBReplayGainAnalyzer : NSObject
 /// The \c NSErrorDomain used by \c SFBReplayGainAnalyzer
 extern NSErrorDomain const SFBReplayGainAnalyzerErrorDomain NS_SWIFT_NAME(ReplayGainAnalyzer.ErrorDomain);
 
-/// Possible \c NSError  error codes used by \c SFBReplayGainAnalyzer
+/// Possible \c NSError error codes used by \c SFBReplayGainAnalyzer
 typedef NS_ERROR_ENUM(SFBReplayGainAnalyzerErrorDomain, SFBReplayGainAnalyzerErrorCode) {
 	/// File format not supported
 	SFBReplayGainAnalyzerErrorCodeFileFormatNotSupported		= 0,

--- a/Decoders/SFBAudioDecoder.h
+++ b/Decoders/SFBAudioDecoder.h
@@ -59,8 +59,10 @@ extern NSErrorDomain const SFBAudioDecoderErrorDomain NS_SWIFT_NAME(AudioDecoder
 
 /// Possible \c NSError  error codes used by \c SFBAudioDecoder
 typedef NS_ERROR_ENUM(SFBAudioDecoderErrorDomain, SFBAudioDecoderErrorCode) {
-	SFBAudioDecoderErrorCodeFileNotFound	= 0,		///< File not found
-	SFBAudioDecoderErrorCodeInputOutput		= 1			///< Input/output error
+	/// File not found
+	SFBAudioDecoderErrorCodeFileNotFound	= 0,
+	/// Input/output error
+	SFBAudioDecoderErrorCodeInputOutput		= 1
 } NS_SWIFT_NAME(AudioDecoder.ErrorCode);
 
 NS_ASSUME_NONNULL_END

--- a/Decoders/SFBAudioDecoder.h
+++ b/Decoders/SFBAudioDecoder.h
@@ -57,7 +57,7 @@ NS_SWIFT_NAME(AudioDecoder) @interface SFBAudioDecoder : NSObject <SFBPCMDecodin
 /// The \c NSErrorDomain used by \c SFBAudioDecoder and subclasses
 extern NSErrorDomain const SFBAudioDecoderErrorDomain NS_SWIFT_NAME(AudioDecoder.ErrorDomain);
 
-/// Possible \c NSError  error codes used by \c SFBAudioDecoder
+/// Possible \c NSError error codes used by \c SFBAudioDecoder
 typedef NS_ERROR_ENUM(SFBAudioDecoderErrorDomain, SFBAudioDecoderErrorCode) {
 	/// File not found
 	SFBAudioDecoderErrorCodeFileNotFound	= 0,

--- a/Decoders/SFBAudioDecoder.m
+++ b/Decoders/SFBAudioDecoder.m
@@ -237,7 +237,7 @@ static NSMutableArray *_registeredSubclasses = nil;
 	subclassInfo.priority = priority;
 
 	[_registeredSubclasses addObject:subclassInfo];
-	[_registeredSubclasses sortUsingComparator:^NSComparisonResult(id  _Nonnull obj1, id  _Nonnull obj2) {
+	[_registeredSubclasses sortUsingComparator:^NSComparisonResult(id _Nonnull obj1, id _Nonnull obj2) {
 		return ((SFBAudioDecoderSubclassInfo *)obj1).priority < ((SFBAudioDecoderSubclassInfo *)obj2).priority;
 	}];
 }

--- a/Decoders/SFBAudioDecoding.h
+++ b/Decoders/SFBAudioDecoding.h
@@ -14,16 +14,26 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Additional audio format IDs
 typedef NS_ENUM(UInt32, SFBAudioFormatID) {
-	SFBAudioFormatIDDirectStreamDigital 	= 'DSD ',	///< Direct Stream Digital (DSD)
-	SFBAudioFormatIDDoP 					= 'DoP ',	///< DSD over PCM (DoP)
-	SFBAudioFormatIDModule 					= 'MOD ',	///< Module
-	SFBAudioFormatIDMonkeysAudio 			= 'APE ',	///< Monkey's Audio (APE)
-	SFBAudioFormatIDMPEG1 					= 'MPG1',	///< MPEG-1 (Layer I, II, or III)
-	SFBAudioFormatIDMusepack 				= 'MPC ',	///< Musepack
-	SFBAudioFormatIDSpeex 					= 'SPX ',	///< Ogg Speex
-	SFBAudioFormatIDTrueAudio 				= 'TTA ',	///< True Audio
-	SFBAudioFormatIDVorbis 					= 'OGG ',	///< Ogg Vorbis
-	SFBAudioFormatIDWavPack 				= 'WV  '	///< WavPack
+	/// Direct Stream Digital (DSD)
+	SFBAudioFormatIDDirectStreamDigital 	= 'DSD ',
+	/// DSD over PCM (DoP)
+	SFBAudioFormatIDDoP 					= 'DoP ',
+	/// Module
+	SFBAudioFormatIDModule 					= 'MOD ',
+	/// Monkey's Audio (APE)
+	SFBAudioFormatIDMonkeysAudio 			= 'APE ',
+	/// MPEG-1 (Layer I, II, or III)
+	SFBAudioFormatIDMPEG1 					= 'MPG1',
+	/// Musepack
+	SFBAudioFormatIDMusepack 				= 'MPC ',
+	/// Ogg Speex
+	SFBAudioFormatIDSpeex 					= 'SPX ',
+	/// True Audio
+	SFBAudioFormatIDTrueAudio 				= 'TTA ',
+	/// Ogg Vorbis
+	SFBAudioFormatIDVorbis 					= 'OGG ',
+	/// WavPack
+	SFBAudioFormatIDWavPack 				= 'WV  '
 } NS_SWIFT_NAME(AudioFormatID);
 
 NS_SWIFT_NAME(AudioDecoding) @protocol SFBAudioDecoding
@@ -44,12 +54,12 @@ NS_SWIFT_NAME(AudioDecoding) @protocol SFBAudioDecoding
 #pragma mark - Setup and Teardown
 
 /// Opens the decoder for reading
-/// @param error An optional pointer to an \c NSError to receive error information
+/// @param error An optional pointer to an \c NSError object to receive error information
 /// @return \c YES on success, \c NO otherwise
 - (BOOL)openReturningError:(NSError **)error NS_SWIFT_NAME(open());
 
 /// Closes the decoder
-/// @param error An optional pointer to an \c NSError to receive error information
+/// @param error An optional pointer to an \c NSError object to receive error information
 /// @return \c YES on success, \c NO otherwise
 - (BOOL)closeReturningError:(NSError **)error NS_SWIFT_NAME(close());
 
@@ -60,7 +70,7 @@ NS_SWIFT_NAME(AudioDecoding) @protocol SFBAudioDecoding
 
 /// Decodes audio
 /// @param buffer A buffer to receive the decoded audio
-/// @param error An optional pointer to an \c NSError to receive error information
+/// @param error An optional pointer to an \c NSError object to receive error information
 /// @return \c YES on success, \c NO otherwise
 - (BOOL)decodeIntoBuffer:(AVAudioBuffer *)buffer error:(NSError **)error NS_SWIFT_NAME(decode(into:));
 

--- a/Decoders/SFBDSDDecoder.h
+++ b/Decoders/SFBDSDDecoder.h
@@ -58,8 +58,10 @@ extern NSErrorDomain const SFBDSDDecoderErrorDomain NS_SWIFT_NAME(DSDDecoder.Err
 
 /// Possible \c NSError  error codes used by \c SFBDSDDecoder
 typedef NS_ERROR_ENUM(SFBDSDDecoderErrorDomain, SFBDSDDecoderErrorCode) {
-	SFBDSDDecoderErrorCodeFileNotFound		= 0,		///< File not found
-	SFBDSDDecoderErrorCodeInputOutput		= 1			///< Input/output error
+	/// File not found
+	SFBDSDDecoderErrorCodeFileNotFound		= 0,
+	/// Input/output error
+	SFBDSDDecoderErrorCodeInputOutput		= 1
 } NS_SWIFT_NAME(DSDDecoder.ErrorCode);
 
 NS_ASSUME_NONNULL_END

--- a/Decoders/SFBDSDDecoder.h
+++ b/Decoders/SFBDSDDecoder.h
@@ -15,7 +15,7 @@ NS_SWIFT_NAME(DSDDecoder) @interface SFBDSDDecoder : NSObject <SFBDSDDecoding>
 /// Returns a set containing the supported path extensions
 @property (class, nonatomic, readonly) NSSet<NSString *> *supportedPathExtensions;
 
-/*!@brief Returns  a set containing the supported MIME types */
+/*!@brief Returns a set containing the supported MIME types */
 @property (class, nonatomic, readonly) NSSet<NSString *> *supportedMIMETypes;
 
 /// Tests whether a file extension is supported
@@ -56,7 +56,7 @@ NS_SWIFT_NAME(DSDDecoder) @interface SFBDSDDecoder : NSObject <SFBDSDDecoding>
 /// The \c NSErrorDomain used by \c SFBDSDDecoder and subclasses
 extern NSErrorDomain const SFBDSDDecoderErrorDomain NS_SWIFT_NAME(DSDDecoder.ErrorDomain);
 
-/// Possible \c NSError  error codes used by \c SFBDSDDecoder
+/// Possible \c NSError error codes used by \c SFBDSDDecoder
 typedef NS_ERROR_ENUM(SFBDSDDecoderErrorDomain, SFBDSDDecoderErrorCode) {
 	/// File not found
 	SFBDSDDecoderErrorCodeFileNotFound		= 0,

--- a/Decoders/SFBDSDDecoding.h
+++ b/Decoders/SFBDSDDecoding.h
@@ -9,18 +9,26 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// DSD sample rates (named as multiples of the CD sample rate, 44,100 Hz)
 typedef NS_ENUM(NSUInteger, SFBDSDSampleRate) {
-	SFBDSDSampleRateDSD64 	= 2822400, 		///< DSD (DSD64)
-	SFBDSDSampleRateDSD128 	= 5644800,		///< Double-rate DSD (DSD128)
-	SFBDSDSampleRateDSD256 	= 11289600,		///< Quad-rate DSD (DSD256)
-	SFBDSDSampleRateDSD512 	= 22579200		///< Octuple-rate DSD (DSD512)
+	/// DSD (DSD64)
+	SFBDSDSampleRateDSD64 	= 2822400,
+	/// Double-rate DSD (DSD128)
+	SFBDSDSampleRateDSD128 	= 5644800,
+	/// Quad-rate DSD (DSD256)
+	SFBDSDSampleRateDSD256 	= 11289600,
+	/// Octuple-rate DSD (DSD512)
+	SFBDSDSampleRateDSD512 	= 22579200
 } NS_SWIFT_NAME(DSDSampleRate);
 
 /// DSD sample rate variants based on 48,000 Hz
 typedef NS_ENUM(NSUInteger, SFBDSDSampleRateVariant) {
-	SFBDSDSampleRateVariantDSD64 	= 3072000, 		///< DSD (DSD64)
-	SFBDSDSampleRateVariantDSD128 	= 6144000,		///< Double-rate DSD (DSD128)
-	SFBDSDSampleRateVariantDSD256 	= 12288000,		///< Quad-rate DSD (DSD256)
-	SFBDSDSampleRateVariantDSD512 	= 24576000		///< Octuple-rate DSD (DSD512)
+	/// DSD (DSD64)
+	SFBDSDSampleRateVariantDSD64 	= 3072000,
+	/// Double-rate DSD (DSD128)
+	SFBDSDSampleRateVariantDSD128 	= 6144000,
+	/// Quad-rate DSD (DSD256)
+	SFBDSDSampleRateVariantDSD256 	= 12288000,
+	/// Octuple-rate DSD (DSD512)
+	SFBDSDSampleRateVariantDSD512 	= 24576000
 } NS_SWIFT_NAME(DSDSampleRateVariant);
 
 // A DSD packet in this context is 8 one-bit samples (a single channel byte) grouped into
@@ -51,7 +59,7 @@ NS_SWIFT_NAME(DSDDecoding) @protocol SFBDSDDecoding <SFBAudioDecoding>
 /// Decodes audio
 /// @param buffer A buffer to receive the decoded audio
 /// @param packetCount The desired number of audio packets
-/// @param error An optional pointer to an \c NSError to receive error information
+/// @param error An optional pointer to an \c NSError object to receive error information
 /// @return \c YES on success, \c NO otherwise
 - (BOOL)decodeIntoBuffer:(AVAudioCompressedBuffer *)buffer packetCount:(AVAudioPacketCount)packetCount error:(NSError **)error NS_SWIFT_NAME(decode(into:count:));
 
@@ -62,7 +70,7 @@ NS_SWIFT_NAME(DSDDecoding) @protocol SFBDSDDecoding <SFBAudioDecoding>
 
 /// Seeks to the specified packet
 /// @param packet The desired packet
-/// @param error An optional pointer to an \c NSError to receive error information
+/// @param error An optional pointer to an \c NSError object to receive error information
 /// @return \c YES on success, \c NO otherwise
 - (BOOL)seekToPacket:(AVAudioFramePosition)packet error:(NSError **)error NS_SWIFT_NAME(seek(to:));
 

--- a/Decoders/SFBDSDDecoding.h
+++ b/Decoders/SFBDSDDecoding.h
@@ -48,10 +48,10 @@ NS_SWIFT_NAME(DSDDecoding) @protocol SFBDSDDecoding <SFBAudioDecoding>
 
 #pragma mark - Position and Length Information
 
-/// Returns the decoder's current packet  position or \c -1 if unknown
+/// Returns the decoder's current packet position or \c -1 if unknown
 @property (nonatomic, readonly) AVAudioFramePosition packetPosition NS_SWIFT_NAME(position);
 
-/// Returns the decoder's length in packets  or \c -1 if unknown
+/// Returns the decoder's length in packets or \c -1 if unknown
 @property (nonatomic, readonly) AVAudioFramePosition packetCount NS_SWIFT_NAME(count);
 
 #pragma mark - Decoding

--- a/Decoders/SFBLoopableRegionDecoder.m
+++ b/Decoders/SFBLoopableRegionDecoder.m
@@ -86,7 +86,7 @@ static inline AVAudioFrameCount SFB_min(AVAudioFrameCount a, AVAudioFrameCount b
 
 - (AVAudioFormat *)processingFormat
 {
-	return  _decoder.processingFormat;
+	return _decoder.processingFormat;
 }
 
 - (AVAudioFormat *)sourceFormat

--- a/Decoders/SFBPCMDecoding.h
+++ b/Decoders/SFBPCMDecoding.h
@@ -22,7 +22,7 @@ NS_SWIFT_NAME(PCMDecoding) @protocol SFBPCMDecoding <SFBAudioDecoding>
 /// Decodes audio
 /// @param buffer A buffer to receive the decoded audio
 /// @param frameLength The desired number of audio frames
-/// @param error An optional pointer to an \c NSError to receive error information
+/// @param error An optional pointer to an \c NSError object to receive error information
 /// @return \c YES on success, \c NO otherwise
 - (BOOL)decodeIntoBuffer:(AVAudioPCMBuffer *)buffer frameLength:(AVAudioFrameCount)frameLength error:(NSError **)error NS_SWIFT_NAME(decode(into:length:));
 
@@ -30,7 +30,7 @@ NS_SWIFT_NAME(PCMDecoding) @protocol SFBPCMDecoding <SFBAudioDecoding>
 
 /// Seeks to the specified frame
 /// @param frame The desired frame
-/// @param error An optional pointer to an \c NSError to receive error information
+/// @param error An optional pointer to an \c NSError object to receive error information
 /// @return \c YES on success, \c NO otherwise
 - (BOOL)seekToFrame:(AVAudioFramePosition)frame error:(NSError **)error NS_SWIFT_NAME(seek(to:));
 

--- a/Decoders/Utilities/AVAudioPCMBuffer+SFBBufferUtilities.h
+++ b/Decoders/Utilities/AVAudioPCMBuffer+SFBBufferUtilities.h
@@ -9,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface AVAudioPCMBuffer (SFBBufferUtilities)
 - (AVAudioFrameCount)appendContentsOfBuffer:(AVAudioPCMBuffer *)buffer NS_SWIFT_NAME(append(_:));
-- (AVAudioFrameCount)appendContentsOfBuffer:(AVAudioPCMBuffer *)buffer readOffset:(AVAudioFrameCount)readOffset frameLength:(AVAudioFrameCount)frameLength  NS_SWIFT_NAME(append(_:from:length:));
+- (AVAudioFrameCount)appendContentsOfBuffer:(AVAudioPCMBuffer *)buffer readOffset:(AVAudioFrameCount)readOffset frameLength:(AVAudioFrameCount)frameLength NS_SWIFT_NAME(append(_:from:length:));
 
 - (AVAudioFrameCount)copyFromBuffer:(AVAudioPCMBuffer *)buffer readOffset:(AVAudioFrameCount)readOffset frameLength:(AVAudioFrameCount)frameLength NS_SWIFT_NAME(copy(_:from:length:));
 - (AVAudioFrameCount)copyFromBuffer:(AVAudioPCMBuffer *)buffer readOffset:(AVAudioFrameCount)readOffset frameLength:(AVAudioFrameCount)frameLength writeOffset:(AVAudioFrameCount)writeOffset NS_SWIFT_NAME(copy(_:from:length:at:));

--- a/Device/SFBAudioOutputDevice.h
+++ b/Device/SFBAudioOutputDevice.h
@@ -23,7 +23,7 @@ NS_SWIFT_NAME(AudioOutputDevice) @interface SFBAudioOutputDevice: SFBAudioDevice
 @property (nonatomic, readonly) BOOL hasMasterVolume;
 /// Returns the master volume scalar or \c NaN on error
 /// @note This returns \c { kAudioDevicePropertyVolumeScalar, kAudioObjectPropertyScopeOutput, kAudioObjectPropertyElementMaster }
-/// @return The master volume scalar  or \c NaN on error
+/// @return The master volume scalar or \c NaN on error
 @property (nonatomic, readonly) float masterVolume;
 /// Sets the master volume scalar
 /// @note This sets \c { kAudioDevicePropertyVolumeScalar, kAudioObjectPropertyScopeOutput, kAudioObjectPropertyElementMaster }

--- a/Input/SFBInputSource.h
+++ b/Input/SFBInputSource.h
@@ -9,8 +9,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Bitmask values used in \c +inputSourceForURL:flags:error:
 typedef NS_OPTIONS(NSUInteger, SFBInputSourceFlags) {
-	SFBInputSourceFlagsMemoryMapFiles			= 1 << 0,	///< Files should be mapped in memory using \c mmap()
-	SFBInputSourceFlagsLoadFilesInMemory		= 1 << 1	///< Files should be fully loaded in memory
+	/// Files should be mapped in memory using \c mmap()
+	SFBInputSourceFlagsMemoryMapFiles			= 1 << 0,
+	/// Files should be fully loaded in memory
+	SFBInputSourceFlagsLoadFilesInMemory		= 1 << 1
 } NS_SWIFT_NAME(InputSource.Flags);
 
 /// An input source
@@ -44,12 +46,12 @@ NS_SWIFT_NAME(InputSource) @interface SFBInputSource : NSObject
 @property (nonatomic, nullable, readonly) NSURL * url;
 
 /// Opens the input source for reading
-/// @param error An optional pointer to an \c NSError to receive error information
+/// @param error An optional pointer to an \c NSError object to receive error information
 /// @return \c YES on success, \c NO otherwise
 - (BOOL)openReturningError:(NSError **)error NS_SWIFT_NAME(open());
 
 /// Closes the input source
-/// @param error An optional pointer to an \c NSError to receive error information
+/// @param error An optional pointer to an \c NSError object to receive error information
 /// @return \c YES on success, \c NO otherwise
 - (BOOL)closeReturningError:(NSError **)error NS_SWIFT_NAME(close());
 
@@ -60,7 +62,7 @@ NS_SWIFT_NAME(InputSource) @interface SFBInputSource : NSObject
 /// @param buffer A buffer to receive data
 /// @param length The maximum number of bytes to read
 /// @param bytesRead The number of bytes actually read
-/// @param error An optional pointer to an \c NSError to receive error information
+/// @param error An optional pointer to an \c NSError object to receive error information
 /// @return \c YES if any bytes were read, \c NO otherwise
 - (BOOL)readBytes:(void *)buffer length:(NSInteger)length bytesRead:(NSInteger *)bytesRead error:(NSError **)error NS_REFINED_FOR_SWIFT;
 
@@ -118,8 +120,10 @@ extern NSErrorDomain const SFBInputSourceErrorDomain NS_SWIFT_NAME(InputSource.E
 
 /// Possible \c NSError  error codes used by \c SFBInputSource
 typedef NS_ERROR_ENUM(SFBInputSourceErrorDomain, SFBInputSourceErrorCode) {
-	SFBInputSourceErrorCodeFileNotFound		= 0,		///< File not found
-	SFBInputSourceErrorCodeInputOutput		= 1			///< Input/output error
+	/// File not found
+	SFBInputSourceErrorCodeFileNotFound		= 0,
+	/// Input/output error
+	SFBInputSourceErrorCodeInputOutput		= 1
 } NS_SWIFT_NAME(InputSource.ErrorCode);
 
 NS_ASSUME_NONNULL_END

--- a/Input/SFBInputSource.h
+++ b/Input/SFBInputSource.h
@@ -18,24 +18,24 @@ typedef NS_OPTIONS(NSUInteger, SFBInputSourceFlags) {
 /// An input source
 NS_SWIFT_NAME(InputSource) @interface SFBInputSource : NSObject
 
-/// Returns an intiailized  \c SFBInputSource object for the given URL or \c nil on failure
+/// Returns an initialized \c SFBInputSource object for the given URL or \c nil on failure
 /// @param url The URL
 /// @param flags Optional flags affecting how \c url is handled
 /// @param error An optional pointer to a \c NSError to receive error information
 /// @return An initialized \c SFBInputSource object for the specified URL, or \c nil on failure
 + (nullable instancetype)inputSourceForURL:(NSURL *)url flags:(SFBInputSourceFlags)flags error:(NSError **)error;
 
-/// Returns an intiailized  \c SFBInputSource for the given byte buffer or \c nil on failure
+/// Returns an initialized \c SFBInputSource for the given byte buffer or \c nil on failure
 /// @param bytes A pointer to the desired byte buffer
 /// @param length The number of bytes in \c bytes
-/// @return An initialized \c SFBInputSource object  or \c nil on faliure
+/// @return An initialized \c SFBInputSource object or \c nil on faliure
 /// @see SFBInputSourceFlags
 + (nullable instancetype)inputSourceWithBytes:(const void *)bytes length:(NSInteger)length error:(NSError **)error;
 
-/// Returns an intiailized  \c SFBInputSource for the given byte buffer or \c nil on failure
+/// Returns an initialized \c SFBInputSource for the given byte buffer or \c nil on failure
 /// @param bytes A pointer to the desired byte buffer
 /// @param length The number of bytes in \c bytes
-/// @return An initialized \c SFBInputSource object  or \c nil on faliure
+/// @return An initialized \c SFBInputSource object or \c nil on faliure
 /// @see SFBInputSourceFlags
 + (nullable instancetype)inputSourceWithBytesNoCopy:(void *)bytes length:(NSInteger)length error:(NSError **)error;
 
@@ -69,7 +69,7 @@ NS_SWIFT_NAME(InputSource) @interface SFBInputSource : NSObject
 /// Returns \c YES if the end of input has been reached
 @property (nonatomic, readonly) BOOL atEOF;
 
-/// Returns  the current offset in the input, in bytes
+/// Returns the current offset in the input, in bytes
 - (BOOL)getOffset:(NSInteger *)offset error:(NSError **)error NS_REFINED_FOR_SWIFT;
 
 /// Returns the length of the input, in bytes
@@ -118,7 +118,7 @@ NS_SWIFT_NAME(InputSource) @interface SFBInputSource : NSObject
 /// The \c NSErrorDomain used by \c SFBInputSource and subclasses
 extern NSErrorDomain const SFBInputSourceErrorDomain NS_SWIFT_NAME(InputSource.ErrorDomain);
 
-/// Possible \c NSError  error codes used by \c SFBInputSource
+/// Possible \c NSError error codes used by \c SFBInputSource
 typedef NS_ERROR_ENUM(SFBInputSourceErrorDomain, SFBInputSourceErrorCode) {
 	/// File not found
 	SFBInputSourceErrorCodeFileNotFound		= 0,

--- a/Metadata/SFBAttachedPicture.h
+++ b/Metadata/SFBAttachedPicture.h
@@ -9,33 +9,57 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// \c SFBAttachedPicture Dictionary Keys
 typedef NSString * SFBAttachedPictureKey NS_TYPED_ENUM NS_SWIFT_NAME(AttachedPicture.Key);
-extern SFBAttachedPictureKey const SFBAttachedPictureKeyImageData;		///< Raw image data (\c NSData)
-extern SFBAttachedPictureKey const SFBAttachedPictureKeyType;			///< Picture type (\c NSNumber)
-extern SFBAttachedPictureKey const SFBAttachedPictureKeyDescription;	///< Picture description (\c NSString)
+/// Raw image data (\c NSData)
+extern SFBAttachedPictureKey const SFBAttachedPictureKeyImageData;
+/// Picture type (\c NSNumber)
+extern SFBAttachedPictureKey const SFBAttachedPictureKeyType;
+/// Picture description (\c NSString)
+extern SFBAttachedPictureKey const SFBAttachedPictureKeyDescription;
 
 /// The function or content of a picture
 typedef NS_ENUM(NSUInteger, SFBAttachedPictureType) {
-	SFBAttachedPictureTypeOther					= 0x00,		///< A type not otherwise enumerated
-	SFBAttachedPictureTypeFileIcon				= 0x01,		///< 32x32 PNG image that should be used as the file icon
-	SFBAttachedPictureTypeOtherFileIcon			= 0x02,		///< File icon of a different size or format
-	SFBAttachedPictureTypeFrontCover			= 0x03,		///< Front cover image of the album
-	SFBAttachedPictureTypeBackCover				= 0x04,		///< Back cover image of the album
-	SFBAttachedPictureTypeLeafletPage			= 0x05,		///< Inside leaflet page of the album
-	SFBAttachedPictureTypeMedia					= 0x06,		///< Image from the album itself
-	SFBAttachedPictureTypeLeadArtist			= 0x07,		///< Picture of the lead artist or soloist
-	SFBAttachedPictureTypeArtist				= 0x08,		///< Picture of the artist or performer
-	SFBAttachedPictureTypeConductor				= 0x09,		///< Picture of the conductor
-	SFBAttachedPictureTypeBand					= 0x0A,		///< Picture of the band or orchestra
-	SFBAttachedPictureTypeComposer				= 0x0B,		///< Picture of the composer
-	SFBAttachedPictureTypeLyricist				= 0x0C,		///< Picture of the lyricist or text writer
-	SFBAttachedPictureTypeRecordingLocation		= 0x0D,		///< Picture of the recording location or studio
-	SFBAttachedPictureTypeDuringRecording		= 0x0E,		///< Picture of the artists during recording
-	SFBAttachedPictureTypeDuringPerformance		= 0x0F,		///< Picture of the artists during performance
-	SFBAttachedPictureTypeMovieScreenCapture	= 0x10,		///< Picture from a movie or video related to the track
-	SFBAttachedPictureTypeColouredFish			= 0x11,		///< Picture of a large, coloured fish
-	SFBAttachedPictureTypeIllustration			= 0x12,		///< Illustration related to the track
-	SFBAttachedPictureTypeBandLogo				= 0x13,		///< Logo of the band or performer
-	SFBAttachedPictureTypePublisherLogo			= 0x14		///< Logo of the publisher (record company)
+	/// A type not otherwise enumerated
+	SFBAttachedPictureTypeOther					= 0x00,
+	/// 32x32 PNG image that should be used as the file icon
+	SFBAttachedPictureTypeFileIcon				= 0x01,
+	/// File icon of a different size or format
+	SFBAttachedPictureTypeOtherFileIcon			= 0x02,
+	/// Front cover image of the album
+	SFBAttachedPictureTypeFrontCover			= 0x03,
+	/// Back cover image of the album
+	SFBAttachedPictureTypeBackCover				= 0x04,
+	/// Inside leaflet page of the album
+	SFBAttachedPictureTypeLeafletPage			= 0x05,
+	/// Image from the album itself
+	SFBAttachedPictureTypeMedia					= 0x06,
+	/// Picture of the lead artist or soloist
+	SFBAttachedPictureTypeLeadArtist			= 0x07,
+	/// Picture of the artist or performer
+	SFBAttachedPictureTypeArtist				= 0x08,
+	/// Picture of the conductor
+	SFBAttachedPictureTypeConductor				= 0x09,
+	/// Picture of the band or orchestra
+	SFBAttachedPictureTypeBand					= 0x0A,
+	/// Picture of the composer
+	SFBAttachedPictureTypeComposer				= 0x0B,
+	/// Picture of the lyricist or text writer
+	SFBAttachedPictureTypeLyricist				= 0x0C,
+	/// Picture of the recording location or studio
+	SFBAttachedPictureTypeRecordingLocation		= 0x0D,
+	/// Picture of the artists during recording
+	SFBAttachedPictureTypeDuringRecording		= 0x0E,
+	/// Picture of the artists during performance
+	SFBAttachedPictureTypeDuringPerformance		= 0x0F,
+	/// Picture from a movie or video related to the track
+	SFBAttachedPictureTypeMovieScreenCapture	= 0x10,
+	/// Picture of a large, coloured fish
+	SFBAttachedPictureTypeColouredFish			= 0x11,
+	/// Illustration related to the track
+	SFBAttachedPictureTypeIllustration			= 0x12,
+	/// Logo of the band or performer
+	SFBAttachedPictureTypeBandLogo				= 0x13,
+	/// Logo of the publisher (record company)
+	SFBAttachedPictureTypePublisherLogo			= 0x14
 } NS_SWIFT_NAME(AttachedPicture.Type);
 
 /// A class encapsulating a single attached picture.
@@ -52,13 +76,13 @@ NS_SWIFT_NAME(AttachedPicture) @interface SFBAttachedPicture : NSObject <NSCopyi
 
 /// Returns an initialized \c SFBAttachedPicture object
 /// @param imageData The raw image data
-/// @param type The  artwork type
+/// @param type The artwork type
 - (instancetype)initWithImageData:(NSData *)imageData type:(SFBAttachedPictureType)type;
 
 /// Returns an initialized \c SFBAttachedPicture object
 /// @param imageData The raw image data
-/// @param type The  artwork type
-/// @param description The  image description
+/// @param type The artwork type
+/// @param description The image description
 - (instancetype)initWithImageData:(NSData *)imageData type:(SFBAttachedPictureType)type description:(nullable NSString *)description NS_DESIGNATED_INITIALIZER;
 
 /// Returns an initialized \c SFBAttachedPicture object or \c nil on error

--- a/Metadata/SFBAudioFile.h
+++ b/Metadata/SFBAudioFile.h
@@ -16,7 +16,7 @@ NS_SWIFT_NAME(AudioFile) @interface SFBAudioFile : NSObject
 /// Returns an array containing the supported file extensions
 @property (class, nonatomic, readonly) NSSet<NSString *> *supportedPathExtensions;
 
-/// Returns  an array containing the supported MIME types
+/// Returns an array containing the supported MIME types
 @property (class, nonatomic, readonly) NSSet<NSString *> *supportedMIMETypes;
 
 /// Tests whether a file extension is supported
@@ -25,16 +25,16 @@ NS_SWIFT_NAME(AudioFile) @interface SFBAudioFile : NSObject
 /// Tests whether a MIME type is supported
 + (BOOL)handlesMIMEType:(NSString *)mimeType;
 
-/// Returns an \c SFBAudioFile  for the specified URL populated with audio properties and metadata or \c nil on failure
+/// Returns an initialized \c SFBAudioFile object for the specified URL populated with audio properties and metadata or \c nil on failure
 /// @param url The URL
-/// @param error An optional pointer to an \c NSError to receive error information
+/// @param error An optional pointer to an \c NSError object to receive error information
 /// @return An \c SFBAudioFile object or \c nil on failure
 + (nullable instancetype)audioFileWithURL:(NSURL *)url error:(NSError **)error NS_SWIFT_NAME(init(readingPropertiesAndMetadataFrom:));
 
 + (instancetype)new NS_UNAVAILABLE;
 - (instancetype)init NS_UNAVAILABLE;
 
-/// Returns an initialized  \c SFBAudioFile object for the specified URL
+/// Returns an initialized \c SFBAudioFile object for the specified URL
 /// @note Does not read audio properties or metadata
 /// @param url The desired URL
 - (nullable instancetype)initWithURL:(NSURL *)url NS_DESIGNATED_INITIALIZER;
@@ -49,12 +49,12 @@ NS_SWIFT_NAME(AudioFile) @interface SFBAudioFile : NSObject
 @property (nonatomic) SFBAudioMetadata *metadata;
 
 /// Reads audio properties and metadata
-/// @param error An optional pointer to an \c NSError to receive error information
+/// @param error An optional pointer to an \c NSError object to receive error information
 /// @return \c YES if successful, \c NO otherwise
 - (BOOL)readPropertiesAndMetadataReturningError:(NSError **)error NS_SWIFT_NAME(readPropertiesAndMetadata());
 
 /// Writes metadata
-/// @param error An optional pointer to an \c NSError to receive error information
+/// @param error An optional pointer to an \c NSError object to receive error information
 /// @return \c YES if successful, \c NO otherwise
 - (BOOL)writeMetadataReturningError:(NSError **)error NS_SWIFT_NAME(writeMetadata());
 
@@ -72,11 +72,14 @@ NS_SWIFT_NAME(AudioFile) @interface SFBAudioFile : NSObject
 /// The \c NSErrorDomain used by \c SFBAudioFile and subclasses
 extern NSErrorDomain const SFBAudioFileErrorDomain NS_SWIFT_NAME(AudioFile.ErrorDomain);
 
-/// Possible \c NSError  error codes used by \c SFBAudioFile
+/// Possible \c NSError error codes used by \c SFBAudioFile
 typedef NS_ERROR_ENUM(SFBAudioFileErrorDomain, SFBAudioFileErrorCode) {
-	SFBAudioFileErrorCodeFileFormatNotRecognized		= 0,	///< File format not recognized
-	SFBAudioFileErrorCodeFileFormatNotSupported			= 1,	///< File format not supported
-	SFBAudioFileErrorCodeInputOutput					= 2		///< Input/output error
+	/// File format not recognized
+	SFBAudioFileErrorCodeFileFormatNotRecognized		= 0,
+	/// File format not supported
+	SFBAudioFileErrorCodeFileFormatNotSupported			= 1,
+	/// Input/output error
+	SFBAudioFileErrorCodeInputOutput					= 2
 } NS_SWIFT_NAME(AudioFile.ErrorCode);
 
 NS_ASSUME_NONNULL_END

--- a/Metadata/SFBAudioFile.m
+++ b/Metadata/SFBAudioFile.m
@@ -132,7 +132,7 @@ static NSMutableArray *_registeredSubclasses = nil;
 	subclassInfo.priority = priority;
 
 	[_registeredSubclasses addObject:subclassInfo];
-	[_registeredSubclasses sortUsingComparator:^NSComparisonResult(id  _Nonnull obj1, id  _Nonnull obj2) {
+	[_registeredSubclasses sortUsingComparator:^NSComparisonResult(id _Nonnull obj1, id _Nonnull obj2) {
 		return ((SFBAudioFileSubclassInfo *)obj1).priority < ((SFBAudioFileSubclassInfo *)obj2).priority;
 	}];
 }

--- a/Metadata/SFBAudioMetadata.h
+++ b/Metadata/SFBAudioMetadata.h
@@ -11,60 +11,99 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Metadata kind bitmask values used in copyMetadataOfKind:from: and removeMetadataOfKind:
 typedef NS_OPTIONS(NSUInteger, SFBAudioMetadataKind) {
-	SFBAudioMetadataKindBasic			= (1u << 0),	///< Basic metadata
-	SFBAudioMetadataKindSorting			= (1u << 1),	///< Sorting metadata
-	SFBAudioMetadataKindGrouping		= (1u << 2),	///< Grouping metadata
-	SFBAudioMetadataKindAdditional		= (1u << 3),	///< Additional metadata
-	SFBAudioMetadataKindReplayGain		= (1u << 4)		///< Replay gain metadata
+	/// Basic metadata
+	SFBAudioMetadataKindBasic			= (1u << 0),
+	/// Sorting metadata
+	SFBAudioMetadataKindSorting			= (1u << 1),
+	/// Grouping metadata
+	SFBAudioMetadataKindGrouping		= (1u << 2),
+	/// Additional metadata
+	SFBAudioMetadataKindAdditional		= (1u << 3),
+	/// Replay gain metadata
+	SFBAudioMetadataKindReplayGain		= (1u << 4)
 } NS_SWIFT_NAME(AudioMetadata.Kind);
 
 typedef NSString * SFBAudioMetadataKey NS_TYPED_ENUM NS_SWIFT_NAME(AudioMetadata.Key);
 
 // Basic metadata dictionary keys
-extern SFBAudioMetadataKey const SFBAudioMetadataKeyTitle;							///< Title (\c NSString)
-extern SFBAudioMetadataKey const SFBAudioMetadataKeyAlbumTitle;						///< Album title (\c NSString)
-extern SFBAudioMetadataKey const SFBAudioMetadataKeyArtist;							///< Artist (\c NSString)
-extern SFBAudioMetadataKey const SFBAudioMetadataKeyAlbumArtist;					///< Album artist (\c NSString)
-extern SFBAudioMetadataKey const SFBAudioMetadataKeyGenre;							///< Genre (\c NSString)
-extern SFBAudioMetadataKey const SFBAudioMetadataKeyComposer;						///< Composer (\c NSString)
-extern SFBAudioMetadataKey const SFBAudioMetadataKeyReleaseDate;					///< Release date (\c NSString)
-extern SFBAudioMetadataKey const SFBAudioMetadataKeyCompilation;					///< Compilation flag (\c NSNumber)
-extern SFBAudioMetadataKey const SFBAudioMetadataKeyTrackNumber;					///< Track number (\c NSNumber)
-extern SFBAudioMetadataKey const SFBAudioMetadataKeyTrackTotal;						///< Track total (\c NSNumber)
-extern SFBAudioMetadataKey const SFBAudioMetadataKeyDiscNumber;						///< Disc number (\c NSNumber)
-extern SFBAudioMetadataKey const SFBAudioMetadataKeyDiscTotal;						///< Disc total (\c NSNumber)
-extern SFBAudioMetadataKey const SFBAudioMetadataKeyLyrics;							///< Lyrics (\c NSString)
-extern SFBAudioMetadataKey const SFBAudioMetadataKeyBPM;							///< Beats per minute (BPM) (\c NSNumber)
-extern SFBAudioMetadataKey const SFBAudioMetadataKeyRating;							///< Rating (\c NSNumber)
-extern SFBAudioMetadataKey const SFBAudioMetadataKeyComment;						///< Comment (\c NSString)
-extern SFBAudioMetadataKey const SFBAudioMetadataKeyISRC;							///< International Standard Recording Code (ISRC) (\c NSString)
-extern SFBAudioMetadataKey const SFBAudioMetadataKeyMCN;							///< Media Catalog Number (MCN) (\c NSString)
-extern SFBAudioMetadataKey const SFBAudioMetadataKeyMusicBrainzReleaseID;			///< MusicBrainz release ID (\c NSString)
-extern SFBAudioMetadataKey const SFBAudioMetadataKeyMusicBrainzRecordingID;			///< MusicBrainz recording ID (\c NSString)
+/// Title (\c NSString)
+extern SFBAudioMetadataKey const SFBAudioMetadataKeyTitle;
+/// Album title (\c NSString)
+extern SFBAudioMetadataKey const SFBAudioMetadataKeyAlbumTitle;
+/// Artist (\c NSString)
+extern SFBAudioMetadataKey const SFBAudioMetadataKeyArtist;
+/// Album artist (\c NSString)
+extern SFBAudioMetadataKey const SFBAudioMetadataKeyAlbumArtist;
+/// Genre (\c NSString)
+extern SFBAudioMetadataKey const SFBAudioMetadataKeyGenre;
+/// Composer (\c NSString)
+extern SFBAudioMetadataKey const SFBAudioMetadataKeyComposer;
+/// Release date (\c NSString)
+extern SFBAudioMetadataKey const SFBAudioMetadataKeyReleaseDate;
+/// Compilation flag (\c NSNumber)
+extern SFBAudioMetadataKey const SFBAudioMetadataKeyCompilation;
+/// Track number (\c NSNumber)
+extern SFBAudioMetadataKey const SFBAudioMetadataKeyTrackNumber;
+/// Track total (\c NSNumber)
+extern SFBAudioMetadataKey const SFBAudioMetadataKeyTrackTotal;
+/// Disc number (\c NSNumber)
+extern SFBAudioMetadataKey const SFBAudioMetadataKeyDiscNumber;
+/// Disc total (\c NSNumber)
+extern SFBAudioMetadataKey const SFBAudioMetadataKeyDiscTotal;
+/// Lyrics (\c NSString)
+extern SFBAudioMetadataKey const SFBAudioMetadataKeyLyrics;
+/// Beats per minute (BPM) (\c NSNumber)
+extern SFBAudioMetadataKey const SFBAudioMetadataKeyBPM;
+/// Rating (\c NSNumber)
+extern SFBAudioMetadataKey const SFBAudioMetadataKeyRating;
+/// Comment (\c NSString)
+extern SFBAudioMetadataKey const SFBAudioMetadataKeyComment;
+/// International Standard Recording Code (ISRC) (\c NSString)
+extern SFBAudioMetadataKey const SFBAudioMetadataKeyISRC;
+/// Media Catalog Number (MCN) (\c NSString)
+extern SFBAudioMetadataKey const SFBAudioMetadataKeyMCN;
+/// MusicBrainz release ID (\c NSString)
+extern SFBAudioMetadataKey const SFBAudioMetadataKeyMusicBrainzReleaseID;
+/// MusicBrainz recording ID (\c NSString)
+extern SFBAudioMetadataKey const SFBAudioMetadataKeyMusicBrainzRecordingID;
 
 // Sorting dictionary keys
-extern SFBAudioMetadataKey const SFBAudioMetadataKeyTitleSortOrder;					///< Title sort order (\c NSString)
-extern SFBAudioMetadataKey const SFBAudioMetadataKeyAlbumTitleSortOrder;			///< Album title sort order (\c NSString)
-extern SFBAudioMetadataKey const SFBAudioMetadataKeyArtistSortOrder;				///< Artist sort order (\c NSString)
-extern SFBAudioMetadataKey const SFBAudioMetadataKeyAlbumArtistSortOrder;			///< Album artist sort order (\c NSString)
-extern SFBAudioMetadataKey const SFBAudioMetadataKeyComposerSortOrder;				///< Composer sort order (\c NSString)
-extern SFBAudioMetadataKey const SFBAudioMetadataKeyGenreSortOrder;					///< Genre sort order (\c NSString)
+/// Title sort order (\c NSString)
+extern SFBAudioMetadataKey const SFBAudioMetadataKeyTitleSortOrder;
+/// Album title sort order (\c NSString)
+extern SFBAudioMetadataKey const SFBAudioMetadataKeyAlbumTitleSortOrder;
+/// Artist sort order (\c NSString)
+extern SFBAudioMetadataKey const SFBAudioMetadataKeyArtistSortOrder;
+/// Album artist sort order (\c NSString)
+extern SFBAudioMetadataKey const SFBAudioMetadataKeyAlbumArtistSortOrder;
+/// Composer sort order (\c NSString)
+extern SFBAudioMetadataKey const SFBAudioMetadataKeyComposerSortOrder;
+/// Genre sort order (\c NSString)
+extern SFBAudioMetadataKey const SFBAudioMetadataKeyGenreSortOrder;
 
 // Grouping dictionary keys
-extern SFBAudioMetadataKey const SFBAudioMetadataKeyGrouping;						///< Grouping (\c NSString)
+/// Grouping (\c NSString)
+extern SFBAudioMetadataKey const SFBAudioMetadataKeyGrouping;
 
 // Additional metadata dictionary keys
-extern SFBAudioMetadataKey const SFBAudioMetadataKeyAdditionalMetadata;				///< Additional metadata (\c NSDictionary)
+/// Additional metadata (\c NSDictionary)
+extern SFBAudioMetadataKey const SFBAudioMetadataKeyAdditionalMetadata;
 
 // Replay gain dictionary keys
-extern SFBAudioMetadataKey const SFBAudioMetadataKeyReplayGainReferenceLoudness;	///< Replay gain reference loudness (\c NSNumber)
-extern SFBAudioMetadataKey const SFBAudioMetadataKeyReplayGainTrackGain;			///< Replay gain track gain (\c NSNumber)
-extern SFBAudioMetadataKey const SFBAudioMetadataKeyReplayGainTrackPeak;			///< Replay gain track peak (\c NSNumber)
-extern SFBAudioMetadataKey const SFBAudioMetadataKeyReplayGainAlbumGain;			///< Replay gain album gain (\c NSNumber)
-extern SFBAudioMetadataKey const SFBAudioMetadataKeyReplayGainAlbumPeak;			///< Replay gain album peak (\c NSNumber)
+/// Replay gain reference loudness (\c NSNumber)
+extern SFBAudioMetadataKey const SFBAudioMetadataKeyReplayGainReferenceLoudness;
+/// Replay gain track gain (\c NSNumber)
+extern SFBAudioMetadataKey const SFBAudioMetadataKeyReplayGainTrackGain;
+/// Replay gain track peak (\c NSNumber)
+extern SFBAudioMetadataKey const SFBAudioMetadataKeyReplayGainTrackPeak;
+/// Replay gain album gain (\c NSNumber)
+extern SFBAudioMetadataKey const SFBAudioMetadataKeyReplayGainAlbumGain;
+/// Replay gain album peak (\c NSNumber)
+extern SFBAudioMetadataKey const SFBAudioMetadataKeyReplayGainAlbumPeak;
 
 // Attached Picture dictionary keys
-extern SFBAudioMetadataKey const SFBAudioMetadataKeyAttachedPictures;				///< Attached pictures (\c NSArray of \c NSDictionary)
+/// Attached pictures (\c NSArray of \c NSDictionary)
+extern SFBAudioMetadataKey const SFBAudioMetadataKeyAttachedPictures;
 
 /// Class supporting commonly-used audio metadata and attached pictures
 NS_SWIFT_NAME(AudioMetadata) @interface SFBAudioMetadata : NSObject <NSCopying>

--- a/Metadata/SFBAudioProperties.h
+++ b/Metadata/SFBAudioProperties.h
@@ -10,13 +10,20 @@ NS_ASSUME_NONNULL_BEGIN
 typedef NSString * SFBAudioPropertiesKey NS_TYPED_ENUM NS_SWIFT_NAME(AudioProperties.Key);
 
 // Audio property dictionary keys
-extern SFBAudioPropertiesKey const SFBAudioPropertiesKeyFormatName;				///< The name of the audio format
-extern SFBAudioPropertiesKey const SFBAudioPropertiesKeyTotalFrames;			///< The total number of audio frames (\c NSNumber)
-extern SFBAudioPropertiesKey const SFBAudioPropertiesKeyChannelsPerFrame;		///< The number of channels (\c NSNumber)
-extern SFBAudioPropertiesKey const SFBAudioPropertiesKeyBitsPerChannel;			///< The number of bits per channel (\c NSNumber)
-extern SFBAudioPropertiesKey const SFBAudioPropertiesKeySampleRate;				///< The sample rate (\c NSNumber)
-extern SFBAudioPropertiesKey const SFBAudioPropertiesKeyDuration;				///< The duration (\c NSNumber)
-extern SFBAudioPropertiesKey const SFBAudioPropertiesKeyBitrate;				///< The audio bitrate (\c NSNumber)
+/// The name of the audio format
+extern SFBAudioPropertiesKey const SFBAudioPropertiesKeyFormatName;
+/// The total number of audio frames (\c NSNumber
+extern SFBAudioPropertiesKey const SFBAudioPropertiesKeyTotalFrames;
+/// The number of channels (\c NSNumber)
+extern SFBAudioPropertiesKey const SFBAudioPropertiesKeyChannelsPerFrame;
+/// The number of bits per channel (\c NSNumber
+extern SFBAudioPropertiesKey const SFBAudioPropertiesKeyBitsPerChannel;
+/// The sample rate (\c NSNumber)
+extern SFBAudioPropertiesKey const SFBAudioPropertiesKeySampleRate;
+/// The duration (\c NSNumber)
+extern SFBAudioPropertiesKey const SFBAudioPropertiesKeyDuration;
+/// The audio bitrate (\c NSNumber)
+extern SFBAudioPropertiesKey const SFBAudioPropertiesKeyBitrate;
 
 /// Class providing information on basic audio properties
 NS_SWIFT_NAME(AudioProperties) @interface SFBAudioProperties : NSObject <NSCopying>

--- a/Player/SFBAudioPlayer.h
+++ b/Player/SFBAudioPlayer.h
@@ -29,9 +29,12 @@ typedef void (^SFBAudioPlayerAVAudioEngineBlock)(AVAudioEngine *engine) NS_SWIFT
 
 /// The possible playback states for \c SFBAudioPlayer
 typedef NS_ENUM(NSUInteger, SFBAudioPlayerPlaybackState) {
-	SFBAudioPlayerPlaybackStatePlaying		= 0,	///<  \c SFBAudioPlayer.engineIsRunning  and \c SFBAudioPlayer.playerNodeIsPlaying
-	SFBAudioPlayerPlaybackStatePaused		= 1,	///<  \c SFBAudioPlayer.engineIsRunning  and \c !SFBAudioPlayer.playerNodeIsPlaying
-	SFBAudioPlayerPlaybackStateStopped		= 2		///<  \c !SFBAudioPlayer.engineIsRunning
+	/// \c SFBAudioPlayer.engineIsRunning  and \c SFBAudioPlayer.playerNodeIsPlaying
+	SFBAudioPlayerPlaybackStatePlaying		= 0,
+	/// \c SFBAudioPlayer.engineIsRunning  and \c !SFBAudioPlayer.playerNodeIsPlaying
+	SFBAudioPlayerPlaybackStatePaused		= 1,
+	/// \c !SFBAudioPlayer.engineIsRunning
+	SFBAudioPlayerPlaybackStateStopped		= 2
 } NS_SWIFT_NAME(AudioPlayer.PlaybackState);
 
 /// An audio player wrapping an \c AVAudioEngine processing graph supplied by \c SFBAudioPlayerNode

--- a/Player/SFBAudioPlayer.h
+++ b/Player/SFBAudioPlayer.h
@@ -29,9 +29,9 @@ typedef void (^SFBAudioPlayerAVAudioEngineBlock)(AVAudioEngine *engine) NS_SWIFT
 
 /// The possible playback states for \c SFBAudioPlayer
 typedef NS_ENUM(NSUInteger, SFBAudioPlayerPlaybackState) {
-	/// \c SFBAudioPlayer.engineIsRunning  and \c SFBAudioPlayer.playerNodeIsPlaying
+	/// \c SFBAudioPlayer.engineIsRunning and \c SFBAudioPlayer.playerNodeIsPlaying
 	SFBAudioPlayerPlaybackStatePlaying		= 0,
-	/// \c SFBAudioPlayer.engineIsRunning  and \c !SFBAudioPlayer.playerNodeIsPlaying
+	/// \c SFBAudioPlayer.engineIsRunning and \c !SFBAudioPlayer.playerNodeIsPlaying
 	SFBAudioPlayerPlaybackStatePaused		= 1,
 	/// \c !SFBAudioPlayer.engineIsRunning
 	SFBAudioPlayerPlaybackStateStopped		= 2

--- a/Player/SFBAudioPlayer.mm
+++ b/Player/SFBAudioPlayer.mm
@@ -23,14 +23,20 @@ namespace {
 @interface SFBAudioPlayer ()
 {
 @private
-	AVAudioEngine 			*_engine;			///< The underlying \c AVAudioEngine instance
-	dispatch_queue_t		_engineQueue;		///< The dispatch queue used to access \c _engine
+	/// The underlying \c AVAudioEngine instance
+	AVAudioEngine 			*_engine;
+	/// The dispatch queue used to access \c _engine
+	dispatch_queue_t		_engineQueue;
 #if TARGET_OS_OSX
-	SFBAudioOutputDevice 	*_outputDevice; 	///< The current output device for \c _engine.outputNode
+	/// The current output device for \c _engine.outputNode
+	SFBAudioOutputDevice 	*_outputDevice;
 #endif
-	SFBAudioPlayerNode		*_playerNode;		///< The player driving the audio processing graph
-	dispatch_queue_t		_queue;				///< The dispatch queue used to access \c _queuedDecoders
-	DecoderQueue 			_queuedDecoders;	///< Decoders enqueued for non-gapless playback
+	/// The player driving the audio processing graph
+	SFBAudioPlayerNode		*_playerNode;
+	/// The dispatch queue used to access \c _queuedDecoders
+	dispatch_queue_t		_queue;
+	/// Decoders enqueued for non-gapless playback
+	DecoderQueue 			_queuedDecoders;
 }
 - (void)handleInterruption:(NSNotification *)notification;
 - (void)setupEngineForGaplessPlaybackOfFormat:(AVAudioFormat *)format forceUpdate:(BOOL)forceUpdate;

--- a/Player/SFBAudioPlayerNode.h
+++ b/Player/SFBAudioPlayerNode.h
@@ -222,7 +222,8 @@ extern NSErrorDomain const SFBAudioPlayerNodeErrorDomain NS_SWIFT_NAME(AudioPlay
 
 /// Possible \c NSError  error codes used by \c SFBAudioPlayerNode
 typedef NS_ERROR_ENUM(SFBAudioPlayerNodeErrorDomain, SFBAudioPlayerNodeErrorCode) {
-	SFBAudioPlayerNodeErrorFormatNotSupported	= 0		///< Format not supported
+	/// Format not supported
+	SFBAudioPlayerNodeErrorFormatNotSupported	= 0
 } NS_SWIFT_NAME(AudioPlayerNode.ErrorCode);
 
 NS_ASSUME_NONNULL_END

--- a/Player/SFBAudioPlayerNode.h
+++ b/Player/SFBAudioPlayerNode.h
@@ -39,7 +39,7 @@ typedef struct SFBAudioPlayerNodePlaybackTime SFBAudioPlayerNodePlaybackTime;
 /// The output format of \c SFBAudioPlayerNode is specified at object initialization and cannot be changed. The output format must be
 /// the standard format, deinterleaved native-endian 32-bit floating point PCM, at any sample rate with any number of channels.
 ///
-/// \c SFBAudioPlayerNode is supplied by objects implementing \c SFBPCMDecoding  (decoders) and supports audio at the same sample rate
+/// \c SFBAudioPlayerNode is supplied by objects implementing \c SFBPCMDecoding (decoders) and supports audio at the same sample rate
 /// and with the same number of channels as the output format. \c SFBAudioPlayerNode supports seeking when supported by the decoder.
 ///
 /// \c SFBAudioPlayerNode maintains a current decoder and a queue of pending decoders. The current decoder is the decoder
@@ -51,10 +51,11 @@ typedef struct SFBAudioPlayerNodePlaybackTime SFBAudioPlayerNodePlaybackTime;
 /// When playback is paused or insufficient audio is available the render block outputs silence.
 ///
 /// Since decoding and rendering are distinct operations performed in separate threads, a GCD timer on the background queue is
-/// used for garbage collection.  This is necessary because state data created in the decoding thread needs to live until
+/// used for garbage collection. This is necessary because state data created in the decoding thread needs to live until
 /// rendering is complete, which cannot occur until after decoding is complete.
 ///
 /// \c SFBAudioPlayerNode supports delegate-based callbacks for the following events:
+///
 ///  1. Decoding started
 ///  2. Decoding complete
 ///  3. Decoding canceled
@@ -220,7 +221,7 @@ NS_SWIFT_NAME(AudioPlayerNode.Delegate) @protocol SFBAudioPlayerNodeDelegate <NS
 /// The \c NSErrorDomain used by \c SFBAudioPlayerNode
 extern NSErrorDomain const SFBAudioPlayerNodeErrorDomain NS_SWIFT_NAME(AudioPlayerNode.ErrorDomain);
 
-/// Possible \c NSError  error codes used by \c SFBAudioPlayerNode
+/// Possible \c NSError error codes used by \c SFBAudioPlayerNode
 typedef NS_ERROR_ENUM(SFBAudioPlayerNodeErrorDomain, SFBAudioPlayerNodeErrorCode) {
 	/// Format not supported
 	SFBAudioPlayerNodeErrorFormatNotSupported	= 0

--- a/Player/SFBAudioPlayerNode.mm
+++ b/Player/SFBAudioPlayerNode.mm
@@ -177,7 +177,7 @@ namespace {
 			return true;
 		}
 
-		/// Seeks to the desired frame  in the converter's *output* sample rate
+		/// Seeks to the desired frame in the converter's *output* sample rate
 		bool PerformSeek()
 		{
 			AVAudioFramePosition seekOffset = mFrameToSeek.load();

--- a/Player/SFBAudioPlayerNode.mm
+++ b/Player/SFBAudioPlayerNode.mm
@@ -90,21 +90,32 @@ namespace {
 			eMarkedForRemovalFlag 	= 1u << 5
 		};
 
-		const uint64_t			mSequenceNumber;	///< Monotonically increasing instance counter
+		/// Monotonically increasing instance counter
+		const uint64_t			mSequenceNumber;
 
-		std::atomic_uint 		mFlags; 			///< Decoder state data flags
-		std::atomic_int64_t 	mFramesDecoded; 	///< The number of frames decoded in the converter's *input* sample rate
-		std::atomic_int64_t 	mFramesConverted;	///< The number of frames converted in the converter's *output* sample rate
-		std::atomic_int64_t 	mFramesRendered;	///< The number of frames rendered in the converter's *output* sample rate
-		std::atomic_int64_t 	mFrameLength;		///< The total number of audio frames, in the decoder's sample rate
-		std::atomic_int64_t 	mFrameToSeek;		///< The desired seek offset, in the converter's *output* sample rate
+		/// Decoder state data flags
+		std::atomic_uint 		mFlags;
+		/// The number of frames decoded in the converter's *input* sample rate
+		std::atomic_int64_t 	mFramesDecoded;
+		/// The number of frames converted in the converter's *output* sample rate
+		std::atomic_int64_t 	mFramesConverted;
+		/// The number of frames rendered in the converter's *output* sample rate
+		std::atomic_int64_t 	mFramesRendered;
+		/// The total number of audio frames, in the decoder's sample rate
+		std::atomic_int64_t 	mFrameLength;
+		/// The desired seek offset, in the converter's *output* sample rate
+		std::atomic_int64_t 	mFrameToSeek;
 
 //	private:
-		id <SFBPCMDecoding> 	mDecoder; 			///< Decodes audio from the source representation to PCM
-		AVAudioConverter 		*mConverter;		///< Converts audio from the decoder's processing format to PCM
+		/// Decodes audio from the source representation to PCM
+		id <SFBPCMDecoding> 	mDecoder;
+		/// Converts audio from the decoder's processing format to PCM
+		AVAudioConverter 		*mConverter;
 	private:
-		AVAudioPCMBuffer 		*mDecodeBuffer;		///< Buffer used internally for buffering during conversion
-		static uint64_t			sSequenceNumber; 	///< Next sequence number to use
+		/// Buffer used internally for buffering during conversion
+		AVAudioPCMBuffer 		*mDecodeBuffer;
+		/// Next sequence number to use
+		static uint64_t			sSequenceNumber;
 
 	public:
 		DecoderStateData(id <SFBPCMDecoding> decoder, AVAudioFormat *format, AVAudioFrameCount frameCapacity = kDefaultBufferSize)
@@ -324,8 +335,10 @@ namespace {
 @interface SFBAudioPlayerNode ()
 {
 @private
-	dispatch_queue_t				_queue;				///< The dispatch queue used to access \c _queuedDecoders
-	DecoderQueue 					_queuedDecoders;	///< Decoders enqueued for playback
+	/// The dispatch queue used to access \c _queuedDecoders
+	dispatch_queue_t				_queue;
+	/// Decoders enqueued for playback
+	DecoderQueue 					_queuedDecoders;
 
 	// Decoding thread variables
 	std::thread 					_decodingThread;

--- a/Player/Utilities/AudioFormat.cpp
+++ b/Player/Utilities/AudioFormat.cpp
@@ -163,9 +163,9 @@ SFB::CFString SFB::Audio::Format::Description() const
 		UInt32 sourceBitDepth = 0;
 		switch(mFormatFlags) {
 			case kAppleLosslessFormatFlag_16BitSourceData:		sourceBitDepth = 16;	break;
-    		case kAppleLosslessFormatFlag_20BitSourceData:		sourceBitDepth = 20;	break;
-    		case kAppleLosslessFormatFlag_24BitSourceData:		sourceBitDepth = 24;	break;
-    		case kAppleLosslessFormatFlag_32BitSourceData:		sourceBitDepth = 32;	break;
+			case kAppleLosslessFormatFlag_20BitSourceData:		sourceBitDepth = 20;	break;
+			case kAppleLosslessFormatFlag_24BitSourceData:		sourceBitDepth = 24;	break;
+			case kAppleLosslessFormatFlag_32BitSourceData:		sourceBitDepth = 32;	break;
 		}
 
 		if(0 != sourceBitDepth)

--- a/Player/Utilities/AudioRingBuffer.h
+++ b/Player/Utilities/AudioRingBuffer.h
@@ -94,7 +94,7 @@ namespace SFB {
 			/*! @brief Get the format of this \c BufferList */
 			inline const Format& GetFormat() const						{ return mFormat; }
 
-			/*! @brief  Get the number of frames available for reading */
+			/*! @brief Get the number of frames available for reading */
 			size_t GetFramesAvailableToRead() const;
 
 			/*! @brief Get the free space available for writing in frames */

--- a/Player/Utilities/RingBuffer.h
+++ b/Player/Utilities/RingBuffer.h
@@ -81,7 +81,7 @@ namespace SFB {
 		/*! @brief Get the capacity of this RingBuffer in bytes */
 		inline size_t GetCapacityBytes() const						{ return mCapacityBytes; }
 
-		/*! @brief  Get the number of bytes available for reading */
+		/*! @brief Get the number of bytes available for reading */
 		size_t GetBytesAvailableToRead() const;
 
 		/*! @brief Get the free space available for writing in bytes */

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 About SFBAudioEngine
 ====================
 
-SFBAudioEngine is a set of Objective-C and Objective-C++ classes enabling macOS (10.15+) and iOS (13.0+) applications to easily play audio.  SFBAudioEngine supports the following formats:
+SFBAudioEngine is a set of Objective-C and Objective-C++ classes enabling macOS (10.15+) and iOS (13.0+) applications to easily play audio. SFBAudioEngine supports the following formats:
 
 * WAVE
 * AIFF


### PR DESCRIPTION
Replace `///<` comments because Xcode doesn't like them as much as `///` comments on the preceding line