### PR TITLE
In -dictionaryRepresentation don't add description if nil

### DIFF
--- a/Metadata/SFBAttachedPicture.m
+++ b/Metadata/SFBAttachedPicture.m
@@ -66,9 +66,13 @@ SFBAttachedPictureKey const SFBAttachedPictureKeyDescription	= @"Description";
 
 - (NSDictionary *)dictionaryRepresentation
 {
-	return @{ SFBAttachedPictureKeyImageData: self.imageData,
-			  SFBAttachedPictureKeyType: @(self.pictureType),
-			  SFBAttachedPictureKeyDescription: self.pictureDescription };
+	if(self.pictureDescription)
+		return @{ SFBAttachedPictureKeyImageData: self.imageData,
+				  SFBAttachedPictureKeyType: @(self.pictureType),
+				  SFBAttachedPictureKeyDescription: self.pictureDescription };
+	else
+		return @{ SFBAttachedPictureKeyImageData: self.imageData,
+				  SFBAttachedPictureKeyType: @(self.pictureType) };
 }
 
 @end


### PR DESCRIPTION
`nil` values are prohibited in Objective-C containers