### PR TITLE
Audio properties renaming to better match AVF

### DIFF
--- a/Metadata/AddAudioPropertiesToDictionary.mm
+++ b/Metadata/AddAudioPropertiesToDictionary.mm
@@ -15,7 +15,7 @@ void SFB::Audio::AddAudioPropertiesToDictionary(const TagLib::AudioProperties *p
 		dictionary[SFBAudioPropertiesKeyDuration] = @(properties->length());
 
 	if(properties->channels())
-		dictionary[SFBAudioPropertiesKeyChannelsPerFrame] = @(properties->channels());
+		dictionary[SFBAudioPropertiesKeyChannelCount] = @(properties->channels());
 
 	if(properties->sampleRate())
 		dictionary[SFBAudioPropertiesKeySampleRate] = @(properties->sampleRate());

--- a/Metadata/SFBAIFFFile.mm
+++ b/Metadata/SFBAIFFFile.mm
@@ -70,7 +70,7 @@
 		if(properties->sampleWidth())
 			propertiesDictionary[SFBAudioPropertiesKeyBitsPerChannel] = @(properties->sampleWidth());
 		if(properties->sampleFrames())
-			propertiesDictionary[SFBAudioPropertiesKeyTotalFrames] = @(properties->sampleFrames());
+			propertiesDictionary[SFBAudioPropertiesKeyFrameLength] = @(properties->sampleFrames());
 	}
 
 	SFBAudioMetadata *metadata = [[SFBAudioMetadata alloc] init];

--- a/Metadata/SFBAudioMetadata.m
+++ b/Metadata/SFBAudioMetadata.m
@@ -714,7 +714,7 @@ static id _sharedKeySet;
 	[_metadata setValue:obj forKey:key];
 }
 
-- (nullable id)objectForKeyedSubscript:(SFBAudioMetadataKey)key
+- (id)objectForKeyedSubscript:(SFBAudioMetadataKey)key
 {
 	return _metadata[key];
 }

--- a/Metadata/SFBAudioProperties.h
+++ b/Metadata/SFBAudioProperties.h
@@ -13,9 +13,9 @@ typedef NSString * SFBAudioPropertiesKey NS_TYPED_ENUM NS_SWIFT_NAME(AudioProper
 /// The name of the audio format
 extern SFBAudioPropertiesKey const SFBAudioPropertiesKeyFormatName;
 /// The total number of audio frames (\c NSNumber
-extern SFBAudioPropertiesKey const SFBAudioPropertiesKeyTotalFrames;
+extern SFBAudioPropertiesKey const SFBAudioPropertiesKeyFrameLength;
 /// The number of channels (\c NSNumber)
-extern SFBAudioPropertiesKey const SFBAudioPropertiesKeyChannelsPerFrame;
+extern SFBAudioPropertiesKey const SFBAudioPropertiesKeyChannelCount;
 /// The number of bits per channel (\c NSNumber
 extern SFBAudioPropertiesKey const SFBAudioPropertiesKeyBitsPerChannel;
 /// The sample rate (\c NSNumber)
@@ -39,10 +39,10 @@ NS_SWIFT_NAME(AudioProperties) @interface SFBAudioProperties : NSObject <NSCopyi
 @property (nonatomic, nullable, readonly) NSString *formatName;
 
 /// The total number of audio frames
-@property (nonatomic, nullable, readonly) NSNumber *totalFrames;
+@property (nonatomic, nullable, readonly) NSNumber *frameLength;
 
 /// The number of channels
-@property (nonatomic, nullable, readonly) NSNumber *channelsPerFrame;
+@property (nonatomic, nullable, readonly) NSNumber *channelCount;
 
 /// The number of bits per channel
 @property (nonatomic, nullable, readonly) NSNumber *bitsPerChannel;

--- a/Metadata/SFBAudioProperties.m
+++ b/Metadata/SFBAudioProperties.m
@@ -7,8 +7,8 @@
 
 // Key names for the properties dictionary
 SFBAudioPropertiesKey const SFBAudioPropertiesKeyFormatName			= @"Format Name";
-SFBAudioPropertiesKey const SFBAudioPropertiesKeyTotalFrames		= @"Total Frames";
-SFBAudioPropertiesKey const SFBAudioPropertiesKeyChannelsPerFrame	= @"Channels Per Frame";
+SFBAudioPropertiesKey const SFBAudioPropertiesKeyFrameLength		= @"Frame Length";
+SFBAudioPropertiesKey const SFBAudioPropertiesKeyChannelCount		= @"Channel Count";
 SFBAudioPropertiesKey const SFBAudioPropertiesKeyBitsPerChannel		= @"Bits Per Channel";
 SFBAudioPropertiesKey const SFBAudioPropertiesKeySampleRate			= @"Sample Rate";
 SFBAudioPropertiesKey const SFBAudioPropertiesKeyDuration			= @"Duration";
@@ -35,8 +35,8 @@ SFBAudioPropertiesKey const SFBAudioPropertiesKeyBitrate			= @"Bitrate";
 	if((self = [super init])) {
 		NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
 		dictionary[SFBAudioPropertiesKeyFormatName] 		= dictionaryRepresentation[SFBAudioPropertiesKeyFormatName];
-		dictionary[SFBAudioPropertiesKeyTotalFrames] 		= dictionaryRepresentation[SFBAudioPropertiesKeyTotalFrames];
-		dictionary[SFBAudioPropertiesKeyChannelsPerFrame] 	= dictionaryRepresentation[SFBAudioPropertiesKeyChannelsPerFrame];
+		dictionary[SFBAudioPropertiesKeyFrameLength] 		= dictionaryRepresentation[SFBAudioPropertiesKeyFrameLength];
+		dictionary[SFBAudioPropertiesKeyChannelCount] 	= dictionaryRepresentation[SFBAudioPropertiesKeyChannelCount];
 		dictionary[SFBAudioPropertiesKeyBitsPerChannel] 	= dictionaryRepresentation[SFBAudioPropertiesKeyBitsPerChannel];
 		dictionary[SFBAudioPropertiesKeySampleRate] 		= dictionaryRepresentation[SFBAudioPropertiesKeySampleRate];
 		dictionary[SFBAudioPropertiesKeyDuration] 			= dictionaryRepresentation[SFBAudioPropertiesKeyDuration];
@@ -57,14 +57,14 @@ SFBAudioPropertiesKey const SFBAudioPropertiesKeyBitrate			= @"Bitrate";
 	return [_properties objectForKey:SFBAudioPropertiesKeyFormatName];
 }
 
-- (NSNumber *)totalFrames
+- (NSNumber *)frameLength
 {
-	return [_properties objectForKey:SFBAudioPropertiesKeyTotalFrames];
+	return [_properties objectForKey:SFBAudioPropertiesKeyFrameLength];
 }
 
-- (NSNumber *)channelsPerFrame
+- (NSNumber *)channelCount
 {
-	return [_properties objectForKey:SFBAudioPropertiesKeyChannelsPerFrame];
+	return [_properties objectForKey:SFBAudioPropertiesKeyChannelCount];
 }
 
 - (NSNumber *)bitsPerChannel
@@ -106,7 +106,7 @@ SFBAudioPropertiesKey const SFBAudioPropertiesKeyBitrate			= @"Bitrate";
 	return [_properties valueForKey:key];
 }
 
-- (nullable id)objectForKeyedSubscript:(SFBAudioPropertiesKey)key
+- (id)objectForKeyedSubscript:(SFBAudioPropertiesKey)key
 {
 	return _properties[key];
 }

--- a/Metadata/SFBDSDIFFFile.mm
+++ b/Metadata/SFBDSDIFFFile.mm
@@ -71,7 +71,7 @@
 		if(properties->bitsPerSample())
 			propertiesDictionary[SFBAudioPropertiesKeyBitsPerChannel] = @(properties->bitsPerSample());
 		if(properties->sampleCount())
-			propertiesDictionary[SFBAudioPropertiesKeyTotalFrames] = @(properties->sampleCount());
+			propertiesDictionary[SFBAudioPropertiesKeyFrameLength] = @(properties->sampleCount());
 	}
 
 	SFBAudioMetadata *metadata = [[SFBAudioMetadata alloc] init];

--- a/Metadata/SFBDSFFile.mm
+++ b/Metadata/SFBDSFFile.mm
@@ -70,7 +70,7 @@
 		if(properties->bitsPerSample())
 			propertiesDictionary[SFBAudioPropertiesKeyBitsPerChannel] = @(properties->bitsPerSample());
 		if(properties->sampleCount())
-			propertiesDictionary[SFBAudioPropertiesKeyTotalFrames] = @(properties->sampleCount());
+			propertiesDictionary[SFBAudioPropertiesKeyFrameLength] = @(properties->sampleCount());
 	}
 
 	SFBAudioMetadata *metadata = [[SFBAudioMetadata alloc] init];

--- a/Metadata/SFBFLACFile.mm
+++ b/Metadata/SFBFLACFile.mm
@@ -76,7 +76,7 @@
 		if(properties->bitsPerSample())
 			propertiesDictionary[SFBAudioPropertiesKeyBitsPerChannel] = @(properties->bitsPerSample());
 		if(properties->sampleFrames())
-			propertiesDictionary[SFBAudioPropertiesKeyTotalFrames] = @(properties->sampleFrames());
+			propertiesDictionary[SFBAudioPropertiesKeyFrameLength] = @(properties->sampleFrames());
 	}
 
 	// Add all tags that are present

--- a/Metadata/SFBMP3File.mm
+++ b/Metadata/SFBMP3File.mm
@@ -98,7 +98,7 @@
 #endif
 
 		if(properties->xingHeader() && properties->xingHeader()->totalFrames())
-			propertiesDictionary[SFBAudioPropertiesKeyTotalFrames] = @(properties->xingHeader()->totalFrames());
+			propertiesDictionary[SFBAudioPropertiesKeyFrameLength] = @(properties->xingHeader()->totalFrames());
 	}
 
 	SFBAudioMetadata *metadata = [[SFBAudioMetadata alloc] init];

--- a/Metadata/SFBMonkeysAudioFile.mm
+++ b/Metadata/SFBMonkeysAudioFile.mm
@@ -71,7 +71,7 @@
 		if(properties->bitsPerSample())
 			propertiesDictionary[SFBAudioPropertiesKeyBitsPerChannel] = @(properties->bitsPerSample());
 		if(properties->sampleFrames())
-			propertiesDictionary[SFBAudioPropertiesKeyTotalFrames] = @(properties->sampleFrames());
+			propertiesDictionary[SFBAudioPropertiesKeyFrameLength] = @(properties->sampleFrames());
 	}
 
 	SFBAudioMetadata *metadata = [[SFBAudioMetadata alloc] init];

--- a/Metadata/SFBMusepackFile.mm
+++ b/Metadata/SFBMusepackFile.mm
@@ -69,7 +69,7 @@
 		SFB::Audio::AddAudioPropertiesToDictionary(properties, propertiesDictionary);
 
 		if(properties->sampleFrames())
-			propertiesDictionary[SFBAudioPropertiesKeyTotalFrames] = @(properties->sampleFrames());
+			propertiesDictionary[SFBAudioPropertiesKeyFrameLength] = @(properties->sampleFrames());
 	}
 
 	SFBAudioMetadata *metadata = [[SFBAudioMetadata alloc] init];

--- a/Metadata/SFBTrueAudioFile.mm
+++ b/Metadata/SFBTrueAudioFile.mm
@@ -71,7 +71,7 @@
 		if(properties->bitsPerSample())
 			propertiesDictionary[SFBAudioPropertiesKeyBitsPerChannel] = @(properties->bitsPerSample());
 		if(properties->sampleFrames())
-			propertiesDictionary[SFBAudioPropertiesKeyTotalFrames] = @(properties->sampleFrames());
+			propertiesDictionary[SFBAudioPropertiesKeyFrameLength] = @(properties->sampleFrames());
 	}
 
 	// Add all tags that are present

--- a/Metadata/SFBWAVEFile.mm
+++ b/Metadata/SFBWAVEFile.mm
@@ -71,7 +71,7 @@
 		if(properties->sampleWidth())
 			propertiesDictionary[SFBAudioPropertiesKeyBitsPerChannel] = @(properties->sampleWidth());
 		if(properties->sampleFrames())
-			propertiesDictionary[SFBAudioPropertiesKeyTotalFrames] = @(properties->sampleFrames());
+			propertiesDictionary[SFBAudioPropertiesKeyFrameLength] = @(properties->sampleFrames());
 	}
 
 	SFBAudioMetadata *metadata = [[SFBAudioMetadata alloc] init];

--- a/Metadata/SFBWavPackFile.mm
+++ b/Metadata/SFBWavPackFile.mm
@@ -71,7 +71,7 @@
 		if(properties->bitsPerSample())
 			propertiesDictionary[SFBAudioPropertiesKeyBitsPerChannel] = @(properties->bitsPerSample());
 		if(properties->sampleFrames())
-			propertiesDictionary[SFBAudioPropertiesKeyTotalFrames] = @(properties->sampleFrames());
+			propertiesDictionary[SFBAudioPropertiesKeyFrameLength] = @(properties->sampleFrames());
 	}
 
 	SFBAudioMetadata *metadata = [[SFBAudioMetadata alloc] init];


### PR DESCRIPTION
Rename `totalFrames` to `frameLength` and `channelsPerFrame` to `channelCount`