### PR TITLE
Add SFBDummyClass to enable UBSan

### DIFF
--- a/SFBAudioEngine.xcodeproj/project.pbxproj
+++ b/SFBAudioEngine.xcodeproj/project.pbxproj
@@ -161,6 +161,7 @@
 		326D3CCE242D2A21002AEC52 /* SFBWavPackFile.h in Headers */ = {isa = PBXBuildFile; fileRef = 322859BD24241D780080B500 /* SFBWavPackFile.h */; };
 		326D3CCF242D2A21002AEC52 /* SFBWavPackFile.mm in Sources */ = {isa = PBXBuildFile; fileRef = 322859BC24241D780080B500 /* SFBWavPackFile.mm */; };
 		3275D9972466F3D90055308E /* SFBReplayGainAnalyzer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3275D9962466F3D90055308E /* SFBReplayGainAnalyzer.swift */; };
+		327D7887254711000026C26C /* SFBDummyClass.m in Sources */ = {isa = PBXBuildFile; fileRef = 327D7882254710470026C26C /* SFBDummyClass.m */; };
 		328DDD2E2544676600B6A093 /* ByteStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 328DDD2D2544676600B6A093 /* ByteStream.h */; };
 		328DDD642544E73200B6A093 /* SFBAudioExporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 328DDD622544E73200B6A093 /* SFBAudioExporter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		328DDD652544E73200B6A093 /* SFBAudioExporter.m in Sources */ = {isa = PBXBuildFile; fileRef = 328DDD632544E73200B6A093 /* SFBAudioExporter.m */; };
@@ -343,6 +344,8 @@
 		326D3C9F242D0291002AEC52 /* SFBAudioFile+Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "SFBAudioFile+Internal.h"; sourceTree = "<group>"; };
 		326D3CAA242D1D3C002AEC52 /* TagLibStringUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TagLibStringUtilities.h; sourceTree = "<group>"; };
 		3275D9962466F3D90055308E /* SFBReplayGainAnalyzer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SFBReplayGainAnalyzer.swift; sourceTree = "<group>"; };
+		327D7881254710470026C26C /* SFBDummyClass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SFBDummyClass.h; sourceTree = "<group>"; };
+		327D7882254710470026C26C /* SFBDummyClass.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SFBDummyClass.m; sourceTree = "<group>"; };
 		328DDD2D2544676600B6A093 /* ByteStream.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ByteStream.h; sourceTree = "<group>"; };
 		328DDD622544E73200B6A093 /* SFBAudioExporter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SFBAudioExporter.h; sourceTree = "<group>"; };
 		328DDD632544E73200B6A093 /* SFBAudioExporter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SFBAudioExporter.m; sourceTree = "<group>"; };
@@ -562,6 +565,8 @@
 				3252E85610CC9EFD00F1AA23 /* PlayerWindow.xib */,
 				325A5E7D2442A816003138D5 /* SimplePlayer-Bridging-Header.h */,
 				3252E84610CC9EBA00F1AA23 /* SimplePlayer-Info.plist */,
+				327D7881254710470026C26C /* SFBDummyClass.h */,
+				327D7882254710470026C26C /* SFBDummyClass.m */,
 			);
 			path = SimplePlayer;
 			sourceTree = "<group>";
@@ -959,6 +964,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				325A5E7F2442A816003138D5 /* PlayerWindowController.swift in Sources */,
+				327D7887254711000026C26C /* SFBDummyClass.m in Sources */,
 				325A5E7E2442A816003138D5 /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SimplePlayer/SFBDummyClass.h
+++ b/SimplePlayer/SFBDummyClass.h
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2020 Stephen F. Booth <me@sbooth.org>
+ * See https://github.com/sbooth/SFBAudioEngine/blob/master/LICENSE.txt for license information
+ */
+
+@import Foundation;
+
+/// This class only exists so SimplePlayer won't be a pure Swift executable, making ubsan available for debugging SFBAudioEngine
+@interface SFBDummyClass : NSObject
+@end

--- a/SimplePlayer/SFBDummyClass.m
+++ b/SimplePlayer/SFBDummyClass.m
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2020 Stephen F. Booth <me@sbooth.org>
+ * See https://github.com/sbooth/SFBAudioEngine/blob/master/LICENSE.txt for license information
+ */
+
+#import "SFBDummyClass.h"
+
+@implementation SFBDummyClass
+@end


### PR DESCRIPTION
The clang undefined behavior sanitizer is not available for Swift-only targets but it's useful for debugging SFBAudioEngine.