### PR TITLE
-audioPlayerEndOfAudio: fix

### DIFF
--- a/Player/SFBAudioPlayer.mm
+++ b/Player/SFBAudioPlayer.mm
@@ -834,6 +834,10 @@ namespace {
 
 - (void)audioPlayerNodeEndOfAudio:(SFBAudioPlayerNode *)audioPlayerNode
 {
+	auto flags = _flags.load();
+	if((flags & eAudioPlayerFlagRenderingImminent) || (flags & eAudioPlayerFlagHavePendingDecoder))
+		return;
+
 	// Dequeue the next decoder
 	id <SFBPCMDecoding> decoder = [self popDecoderFromInternalQueue];
 	if(decoder) {


### PR DESCRIPTION
Fix for instances where -audioPlayerNodeEndOfAudio: is sent before the next decoder has started rendering, for example when a seek to the last frame of the current decoder occurs.