### PR TITLE
Fix shorten decoding for AIFF-based files and files with no seek table

### DIFF
--- a/Decoders/SFBShortenDecoder.mm
+++ b/Decoders/SFBShortenDecoder.mm
@@ -1100,7 +1100,7 @@ namespace {
 	if(exp >= 0)
 		_sampleRate = (uint32_t)(frac << exp);
 	else
-		_sampleRate = (uint32_t)((frac + (1 << (-frac - 1))) >> -frac);
+		_sampleRate = (uint32_t)((frac + (1 << (-exp - 1))) >> -exp);
 
 	if(len > 18)
 		os_log_info(gSFBAudioDecoderLog, "%u bytes in 'COMM' chunk not parsed", len - 16);

--- a/Decoders/SFBShortenDecoder.mm
+++ b/Decoders/SFBShortenDecoder.mm
@@ -390,6 +390,7 @@ namespace {
 
 	uint32_t _sampleRate;
 	uint32_t _bitsPerSample;
+	bool _bigEndian;
 
 	int32_t **_buffer;
 	int32_t **_offset;
@@ -468,7 +469,9 @@ namespace {
 
 	processingStreamDescription.mFormatID			= kAudioFormatLinearPCM;
 	processingStreamDescription.mFormatFlags		= kAudioFormatFlagIsNonInterleaved | kAudioFormatFlagIsPacked;
-	if(_internal_ftype == TYPE_U16HL || _internal_ftype == TYPE_S16HL)
+	// Apparently *16HL isn't true for 'AIFF'
+//	if(_internal_ftype == TYPE_U16HL || _internal_ftype == TYPE_S16HL)
+	if(_bigEndian)
 		processingStreamDescription.mFormatFlags	|= kAudioFormatFlagIsBigEndian;
 	if(_internal_ftype == TYPE_S8 || _internal_ftype == TYPE_S16HL || _internal_ftype == TYPE_S16LH)
 		processingStreamDescription.mFormatFlags	|= kAudioFormatFlagIsSignedInteger;
@@ -1044,6 +1047,9 @@ namespace {
 							   recoverySuggestion:NSLocalizedString(@"The file's extension may not match the file's type.", @"")];
 		return NO;
 	}
+
+	if(chunkID == 'AIFC')
+		_bigEndian = true;
 
 	// Skip unknown chunks, looking for 'COMM'
 	while((chunkID = chunkData.ReadBE<uint32_t>()) != 'COMM') {

--- a/Decoders/SFBShortenDecoder.mm
+++ b/Decoders/SFBShortenDecoder.mm
@@ -620,8 +620,10 @@ namespace {
 			break;
 
 		// Decode the next _blocksize frames
-		if(![self decodeBlockReturningError:error])
+		if(![self decodeBlockReturningError:error]) {
 			os_log_error(gSFBAudioDecoderLog, "Error decoding Shorten block");
+			return NO;
+		}
 	}
 
 	_framePosition += framesProcessed;

--- a/Decoders/SFBShortenDecoder.mm
+++ b/Decoders/SFBShortenDecoder.mm
@@ -1496,6 +1496,8 @@ namespace {
 			if(!entries.empty() && [self seekTableIsValid:entries startOffset:startOffset])
 				_seekTableEntries = entries;
 		}
+		if(![_inputSource seekToOffset:startOffset error:error])
+			return NO;
 		return YES;
 	}
 


### PR DESCRIPTION
The sample rate is incorrectly calculated from the AIFF 'COMM' chunk and the byte swapping is not performed correctly.