### PR TITLE
Improve ring buffer performance

### DIFF
--- a/Player/Utilities/AudioRingBuffer.h
+++ b/Player/Utilities/AudioRingBuffer.h
@@ -21,11 +21,11 @@ namespace SFB {
 	namespace Audio {
 
 		/*!
-		 * @brief A ring buffer implementation supporting non-interleaved audio.
+		 * @brief A ring buffer supporting non-interleaved audio.
 		 *
 		 * This class is thread safe when used from one reader thread and one writer thread (single producer, single consumer model).
 		 *
-		 * The read and write routines are based on JACK's ringbuffer implementation but are modified for non-interleaved audio.
+		 * The read and write routines were originally based on JACK's ringbuffer implementation.
 		 */
 		class RingBuffer
 		{

--- a/Player/Utilities/RingBuffer.h
+++ b/Player/Utilities/RingBuffer.h
@@ -8,17 +8,17 @@
 #include <atomic>
 #include <memory>
 
-/*! @file RingBuffer.h @brief A generic ring buffer */
+/*! @file RingBuffer.h @brief A ring buffer */
 
 /*! @brief \c SFBAudioEngine's encompassing namespace */
 namespace SFB {
 
 	/*!
-	 * @brief A generic ring buffer implementation
+	 * @brief A ring buffer.
 	 *
 	 * This class is thread safe when used from one reader thread and one writer thread (single producer, single consumer model).
 	 *
-	 * The read and write routines are based on JACK's ringbuffer implementation
+	 * The read and write routines were originally based on JACK's ringbuffer implementation.
 	 */
 	class RingBuffer
 	{


### PR DESCRIPTION
The improvements are mostly in `SFB::RingBuffer` as a stack allocation is avoided in each call to `Read` and `Write`. `SFB::Audio::RingBuffer` also shows a very slight improvement.