### PR TITLE
Use an on-demand collector

### DIFF
--- a/Player/SFBAudioPlayer.mm
+++ b/Player/SFBAudioPlayer.mm
@@ -619,14 +619,14 @@ namespace {
 		return NO;
 	}
 
-	if(forImmediatePlayback)
+	if(forImmediatePlayback) {
 		[self clearInternalDecoderQueue];
-
-	// Failure is unlikely since the audio processing graph was reconfigured for the decoder's processing format
-	if(forImmediatePlayback)
 		success = [_playerNode resetAndEnqueueDecoder:decoder error:error];
+	}
 	else
 		success = [_playerNode enqueueDecoder:decoder error:error];
+
+	// Failure is unlikely since the audio processing graph was reconfigured for the decoder's processing format
 	if(!success) {
 		_flags.fetch_and(~eAudioPlayerFlagHavePendingDecoder);
 		if(self.nowPlaying) {

--- a/Player/SFBAudioPlayerNode.mm
+++ b/Player/SFBAudioPlayerNode.mm
@@ -27,7 +27,6 @@ NSErrorDomain const SFBAudioPlayerNodeErrorDomain = @"org.sbooth.AudioEngine.Aud
 @interface SFBAudioPlayerNode ()
 - (void *)decoderThreadEntry;
 - (void *)notifierThreadEntry;
-- (void *)collectorThreadEntry;
 @end
 
 namespace {
@@ -42,8 +41,7 @@ namespace {
 		eAudioPlayerNodeFlagMuteRequested				= 1u << 2,
 		eAudioPlayerNodeFlagRingBufferNeedsReset		= 1u << 3,
 		eAudioPlayerNodeFlagStopDecoderThread			= 1u << 4,
-		eAudioPlayerNodeFlagStopNotifierThread			= 1u << 5,
-		eAudioPlayerNodeFlagStopCollectorThread			= 1u << 6
+		eAudioPlayerNodeFlagStopNotifierThread			= 1u << 5
 	};
 
 	enum eAudioPlayerNodeRenderEventRingBufferCommands : uint32_t {
@@ -70,15 +68,6 @@ namespace {
 
 		SFBAudioPlayerNode *playerNode = (__bridge SFBAudioPlayerNode *)arg;
 		return [playerNode notifierThreadEntry];
-	}
-
-	void * CollectorThreadEntry(void *arg)
-	{
-		pthread_setname_np("org.sbooth.AudioEngine.AudioPlayerNode.CollectorThread");
-		pthread_set_qos_class_self_np(QOS_CLASS_BACKGROUND, 0);
-
-		SFBAudioPlayerNode *playerNode = (__bridge SFBAudioPlayerNode *)arg;
-		return [playerNode collectorThreadEntry];
 	}
 
 #pragma mark - Constants
@@ -348,9 +337,8 @@ namespace {
 	dispatch_semaphore_t			_notifierSemaphore;
 	dispatch_queue_t				_notificationQueue;
 
-	// Collector thread variables
-	std::thread						_collectorThread;
-	dispatch_semaphore_t			_collectorSemaphore;
+	// Collector
+	dispatch_source_t				_collector;
 
 	// Shared state accessed from multiple threads/queues
 	std::atomic_uint 				_flags;
@@ -566,17 +554,33 @@ namespace {
 			return nil;
 		}
 
-		_collectorSemaphore = dispatch_semaphore_create(0);
-		if(!_collectorSemaphore) {
-			os_log_error(_audioPlayerNodeLog, "dispatch_semaphore_create failed");
+		// Set up the collector
+		_collector = dispatch_source_create(DISPATCH_SOURCE_TYPE_DATA_OR, 0, 0, dispatch_get_global_queue(QOS_CLASS_BACKGROUND, 0));
+		if(!_collector) {
+			os_log_error(_audioPlayerNodeLog, "dispatch_source_create failed");
 			return nil;
 		}
+
+		dispatch_source_set_event_handler(_collector, ^{
+			for(size_t i = 0; i < kDecoderStateArraySize; ++i) {
+				auto decoderState = self->_decoderStateArray[i].load();
+				if(!decoderState || !(decoderState->mFlags.load() & DecoderStateData::eMarkedForRemovalFlag))
+					continue;
+
+				// See comment in -decoderThreadEntry on why I believe it's safe to use store() and not a CAS loop
+				os_log_debug(_audioPlayerNodeLog, "Collecting decoder for \"%{public}@\"", [[NSFileManager defaultManager] displayNameAtPath:decoderState->mDecoder.inputSource.url.path]);
+				self->_decoderStateArray[i].store(nullptr);
+				delete decoderState;
+			}
+		});
+
+		// Start collecting
+		dispatch_resume(_collector);
 
 		// Launch the threads
 		try {
 			_decodingThread = std::thread(DecoderThreadEntry, (__bridge void *)self);
 			_notifierThread = std::thread(NotifierThreadEntry, (__bridge void *)self);
-			_collectorThread = std::thread(CollectorThreadEntry, (__bridge void *)self);
 		}
 
 		catch(const std::exception& e) {
@@ -590,16 +594,11 @@ namespace {
 
 - (void)dealloc
 {
-	_flags.fetch_or(eAudioPlayerNodeFlagStopDecoderThread | eAudioPlayerNodeFlagStopNotifierThread | eAudioPlayerNodeFlagStopCollectorThread);
-
+	_flags.fetch_or(eAudioPlayerNodeFlagStopDecoderThread | eAudioPlayerNodeFlagStopNotifierThread);
 	dispatch_semaphore_signal(_decodingSemaphore);
 	dispatch_semaphore_signal(_notifierSemaphore);
-	dispatch_semaphore_signal(_collectorSemaphore);
-
 	_decodingThread.join();
 	_notifierThread.join();
-	_collectorThread.join();
-
 	while(!_queuedDecoders.empty())
 		_queuedDecoders.pop();
 
@@ -1102,7 +1101,7 @@ namespace {
 
 					_flags.fetch_or(eAudioPlayerNodeFlagRingBufferNeedsReset);
 					decoderState->mFlags.fetch_or(DecoderStateData::eMarkedForRemovalFlag);
-					dispatch_semaphore_signal(self->_collectorSemaphore);
+					dispatch_source_merge_data(_collector, 1);
 
 					// Perform the decoding cancelled notification
 					if([_delegate respondsToSelector:@selector(audioPlayerNode:decodingCanceled:partiallyRendered:)])
@@ -1211,7 +1210,7 @@ namespace {
 
 						// The last action performed with a decoder that has completed rendering is this notification
 						decoderState->mFlags.fetch_or(DecoderStateData::eMarkedForRemovalFlag);
-						dispatch_semaphore_signal(self->_collectorSemaphore);
+						dispatch_source_merge_data(_collector, 1);
 					}
 					else
 						os_log_error(_audioPlayerNodeLog, "Ring buffer command data missing");
@@ -1248,30 +1247,6 @@ namespace {
 	}
 
 	os_log_debug(_audioPlayerNodeLog, "Notifier thread terminating");
-
-	return nullptr;
-}
-
-- (void *)collectorThreadEntry
-{
-	os_log_debug(_audioPlayerNodeLog, "Collector thread starting");
-
-	while(!(_flags.load() & eAudioPlayerNodeFlagStopCollectorThread)) {
-		for(size_t i = 0; i < kDecoderStateArraySize; ++i) {
-			auto decoderState = self->_decoderStateArray[i].load();
-			if(!decoderState || !(decoderState->mFlags.load() & DecoderStateData::eMarkedForRemovalFlag))
-				continue;
-
-			// See comment in -decoderThreadEntry on why I believe it's safe to use store() and not a CAS loop
-			os_log_debug(_audioPlayerNodeLog, "Collecting decoder for \"%{public}@\"", [[NSFileManager defaultManager] displayNameAtPath:decoderState->mDecoder.inputSource.url.path]);
-			self->_decoderStateArray[i].store(nullptr);
-			delete decoderState;
-		}
-
-		dispatch_semaphore_wait(_collectorSemaphore, dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC * 10));
-	}
-
-	os_log_debug(_audioPlayerNodeLog, "Collector thread terminating");
 
 	return nullptr;
 }


### PR DESCRIPTION
The current timer-based collector cannot be triggered on demand and can lead to `No open slots in _decoderStateArray` messages if decoders are enqueued in rapid succession.

Fixes #178 