### PR TITLE
Use AudioProperties::lengthInMilliseconds() for more accurate estimation of duration

### DIFF
--- a/Decoders/SFBOggOpusDecoder.m
+++ b/Decoders/SFBOggOpusDecoder.m
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2006 - 2022 Stephen F. Booth <me@sbooth.org>
+// Copyright (c) 2006 - 2023 Stephen F. Booth <me@sbooth.org>
 // Part of https://github.com/sbooth/SFBAudioEngine
 // MIT license
 //
@@ -28,7 +28,7 @@ static int read_callback(void *stream, unsigned char *ptr, int nbytes)
 	return (int)bytesRead;
 }
 
-static 	int seek_callback(void *stream, opus_int64 offset, int whence)
+static int seek_callback(void *stream, opus_int64 offset, int whence)
 {
 	NSCParameterAssert(stream != NULL);
 
@@ -57,7 +57,7 @@ static 	int seek_callback(void *stream, opus_int64 offset, int whence)
 	return ![decoder->_inputSource seekToOffset:offset error:nil];
 }
 
-static 	opus_int64 tell_callback(void *stream)
+static opus_int64 tell_callback(void *stream)
 {
 	NSCParameterAssert(stream != NULL);
 

--- a/Metadata/AddAudioPropertiesToDictionary.mm
+++ b/Metadata/AddAudioPropertiesToDictionary.mm
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2010 - 2021 Stephen F. Booth <me@sbooth.org>
+// Copyright (c) 2010 - 2023 Stephen F. Booth <me@sbooth.org>
 // Part of https://github.com/sbooth/SFBAudioEngine
 // MIT license
 //
@@ -12,8 +12,8 @@ void SFB::Audio::AddAudioPropertiesToDictionary(const TagLib::AudioProperties *p
 	NSCParameterAssert(properties != nil);
 	NSCParameterAssert(dictionary != nil);
 
-	if(properties->length())
-		dictionary[SFBAudioPropertiesKeyDuration] = @(properties->length());
+	if(properties->lengthInMilliseconds())
+		dictionary[SFBAudioPropertiesKeyDuration] = @(properties->lengthInMilliseconds() / 1000.0);
 
 	if(properties->channels())
 		dictionary[SFBAudioPropertiesKeyChannelCount] = @(properties->channels());


### PR DESCRIPTION
Fixes #248 