### PR TITLE
Fix repeat for region decoding

### DIFF
--- a/Decoders/SFBLoopableRegionDecoder.m
+++ b/Decoders/SFBLoopableRegionDecoder.m
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2006 - 2021 Stephen F. Booth <me@sbooth.org>
+// Copyright (c) 2006 - 2023 Stephen F. Booth <me@sbooth.org>
 // Part of https://github.com/sbooth/SFBAudioEngine
 // MIT license
 //
@@ -54,7 +54,7 @@
 	SFBAudioDecoder *decoder = [[SFBAudioDecoder alloc] initWithInputSource:inputSource error:error];
 	if(!decoder || !decoder.supportsSeeking)
 		return nil;
-	return [self initWithDecoder:decoder framePosition:framePosition frameLength:frameLength error:error];
+	return [self initWithDecoder:decoder framePosition:framePosition frameLength:frameLength repeatCount:repeatCount error:error];
 }
 
 - (instancetype)initWithDecoder:(id <SFBPCMDecoding>)decoder framePosition:(AVAudioFramePosition)framePosition frameLength:(AVAudioFramePosition)frameLength error:(NSError **)error

--- a/Decoders/SFBLoopableRegionDecoder.m
+++ b/Decoders/SFBLoopableRegionDecoder.m
@@ -180,7 +180,7 @@
 		framesRemaining -= _buffer.frameLength;
 
 		// If this pass is finished, seek to the beginning of the region in preparation for the next read
-		if(_repeatCount && _frameLength == (_framesDecoded / _frameLength)) {
+		if(_repeatCount && (_framesDecoded % _frameLength) == 0) {
 			// Only seek to the beginning of the region if more passes remain
 			if((_framesDecoded / _frameLength) < (_repeatCount + 1)) {
 				if(![_decoder seekToFrame:_framePosition error:error])


### PR DESCRIPTION
Currently any repeat count passed to `-initWithInputSource:framePosition:frameLength:repeatCount: error:` is ignored.