### PR TITLE
Rename AudioSubdevice to AudioSubDevice

### DIFF
--- a/Device/AudioObject.swift
+++ b/Device/AudioObject.swift
@@ -464,7 +464,7 @@ extension AudioObject {
 			case kAudioAggregateDeviceClassID: 	return AudioAggregateDevice(objectID)
 			case kAudioEndPointDeviceClassID:	return AudioEndpointDevice(objectID)
 			case kAudioEndPointClassID:			return AudioEndpoint(objectID)
-			case kAudioSubDeviceClassID:		return AudioSubdevice(objectID)
+			case kAudioSubDeviceClassID:		return AudioSubDevice(objectID)
 			default:
 				os_log(.debug, log: audioObjectLog, "Unknown audio device class '%{public}@'", objectClass.fourCC)
 				return AudioDevice(objectID)

--- a/Device/AudioSubDevice.swift
+++ b/Device/AudioSubDevice.swift
@@ -9,10 +9,10 @@ import CoreAudio
 
 /// A HAL audio subdevice
 /// - remark: This class correponds to objects with base class `kAudioSubDeviceClassID`
-public class AudioSubdevice: AudioDevice {
+public class AudioSubDevice: AudioDevice {
 }
 
-extension AudioSubdevice {
+extension AudioSubDevice {
 	/// Returns the extra latency
 	/// - remark: This corresponds to the property `kAudioSubDevicePropertyExtraLatency`
 	public func extraLatency() throws -> Double {
@@ -42,7 +42,7 @@ extension AudioSubdevice {
 	}
 }
 
-extension AudioSubdevice {
+extension AudioSubDevice {
 	/// A thin wrapper around a HAL audio subdevice drift compensation quality setting
 	public struct DriftCompensationQuality: RawRepresentable, ExpressibleByIntegerLiteral, ExpressibleByStringLiteral {
 		/// Minimum quality
@@ -72,7 +72,7 @@ extension AudioSubdevice {
 	}
 }
 
-extension AudioSubdevice.DriftCompensationQuality: CustomDebugStringConvertible {
+extension AudioSubDevice.DriftCompensationQuality: CustomDebugStringConvertible {
 	// A textual representation of this instance, suitable for debugging.
 	public var debugDescription: String {
 		switch self.rawValue {
@@ -86,12 +86,12 @@ extension AudioSubdevice.DriftCompensationQuality: CustomDebugStringConvertible 
 	}
 }
 
-extension AudioSubdevice {
+extension AudioSubDevice {
 	/// Returns `true` if `self` has `selector` in `scope` on `element`
 	/// - parameter selector: The selector of the desired property
 	/// - parameter scope: The desired scope
 	/// - parameter element: The desired element
-	public func hasSelector(_ selector: AudioObjectSelector<AudioSubdevice>, inScope scope: PropertyScope = .global, onElement element: PropertyElement = .main) -> Bool {
+	public func hasSelector(_ selector: AudioObjectSelector<AudioSubDevice>, inScope scope: PropertyScope = .global, onElement element: PropertyElement = .main) -> Bool {
 		return hasProperty(PropertyAddress(PropertySelector(selector.rawValue), scope: scope, element: element))
 	}
 
@@ -100,7 +100,7 @@ extension AudioSubdevice {
 	/// - parameter scope: The desired scope
 	/// - parameter element: The desired element
 	/// - throws: An error if `self` does not have the requested property
-	public func isSelectorSettable(_ selector: AudioObjectSelector<AudioSubdevice>, inScope scope: PropertyScope = .global, onElement element: PropertyElement = .main) throws -> Bool {
+	public func isSelectorSettable(_ selector: AudioObjectSelector<AudioSubDevice>, inScope scope: PropertyScope = .global, onElement element: PropertyElement = .main) throws -> Bool {
 		return try isPropertySettable(PropertyAddress(PropertySelector(selector.rawValue), scope: scope, element: element))
 	}
 
@@ -110,12 +110,12 @@ extension AudioSubdevice {
 	/// - parameter element: The desired element
 	/// - parameter block: A closure to invoke when the property changes or `nil` to remove the previous value
 	/// - throws: An error if the property listener could not be registered
-	public func whenSelectorChanges(_ selector: AudioObjectSelector<AudioSubdevice>, inScope scope: PropertyScope = .global, onElement element: PropertyElement = .main, perform block: PropertyChangeNotificationBlock?) throws {
+	public func whenSelectorChanges(_ selector: AudioObjectSelector<AudioSubDevice>, inScope scope: PropertyScope = .global, onElement element: PropertyElement = .main, perform block: PropertyChangeNotificationBlock?) throws {
 		try whenPropertyChanges(PropertyAddress(PropertySelector(selector.rawValue), scope: scope, element: element), perform: block)
 	}
 }
 
-extension AudioObjectSelector where T == AudioSubdevice {
+extension AudioObjectSelector where T == AudioSubDevice {
 	/// The property selector `kAudioSubDevicePropertyExtraLatency`
 	public static let extraLatency = AudioObjectSelector(kAudioSubDevicePropertyExtraLatency)
 	/// The property selector `kAudioSubDevicePropertyDriftCompensation`

--- a/SFBAudioEngine.xcodeproj/project.pbxproj
+++ b/SFBAudioEngine.xcodeproj/project.pbxproj
@@ -415,7 +415,7 @@
 		32C09BDF253B4EFB00A1932C /* SFBShortenDecoder.mm in Sources */ = {isa = PBXBuildFile; fileRef = 32C09BDD253B4EFB00A1932C /* SFBShortenDecoder.mm */; };
 		32D73969259A771300C0E3F6 /* AudioTransportManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32D73956259A771300C0E3F6 /* AudioTransportManager.swift */; };
 		32D7396A259A771300C0E3F6 /* LevelControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32D73957259A771300C0E3F6 /* LevelControl.swift */; };
-		32D7396B259A771300C0E3F6 /* AudioSubdevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32D73958259A771300C0E3F6 /* AudioSubdevice.swift */; };
+		32D7396B259A771300C0E3F6 /* AudioSubDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32D73958259A771300C0E3F6 /* AudioSubDevice.swift */; };
 		32D7396C259A771300C0E3F6 /* AudioClockDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32D73959259A771300C0E3F6 /* AudioClockDevice.swift */; };
 		32D7396D259A771300C0E3F6 /* AudioObjectProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32D7395A259A771300C0E3F6 /* AudioObjectProperty.swift */; };
 		32D7396E259A771300C0E3F6 /* AudioEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32D7395B259A771300C0E3F6 /* AudioEndpoint.swift */; };
@@ -738,7 +738,7 @@
 		32C212D61091116D00BA2493 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		32D73956259A771300C0E3F6 /* AudioTransportManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AudioTransportManager.swift; sourceTree = "<group>"; };
 		32D73957259A771300C0E3F6 /* LevelControl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LevelControl.swift; sourceTree = "<group>"; };
-		32D73958259A771300C0E3F6 /* AudioSubdevice.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AudioSubdevice.swift; sourceTree = "<group>"; };
+		32D73958259A771300C0E3F6 /* AudioSubDevice.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AudioSubDevice.swift; sourceTree = "<group>"; };
 		32D73959259A771300C0E3F6 /* AudioClockDevice.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AudioClockDevice.swift; sourceTree = "<group>"; };
 		32D7395A259A771300C0E3F6 /* AudioObjectProperty.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AudioObjectProperty.swift; sourceTree = "<group>"; };
 		32D7395B259A771300C0E3F6 /* AudioEndpoint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AudioEndpoint.swift; sourceTree = "<group>"; };
@@ -1018,7 +1018,7 @@
 				32D7395F259A771300C0E3F6 /* AudioStream.swift */,
 				32D7395E259A771300C0E3F6 /* AudioSystemObject.swift */,
 				32D73962259A771300C0E3F6 /* AudioAggregateDevice.swift */,
-				32D73958259A771300C0E3F6 /* AudioSubdevice.swift */,
+				32D73958259A771300C0E3F6 /* AudioSubDevice.swift */,
 				32D73956259A771300C0E3F6 /* AudioTransportManager.swift */,
 				32D73966259A771300C0E3F6 /* BooleanControl.swift */,
 				32D73957259A771300C0E3F6 /* LevelControl.swift */,
@@ -1793,7 +1793,7 @@
 				325116CD2423B15300B02926 /* SFBAttachedPicture.m in Sources */,
 				3229C5AF25CF5D71002395CD /* AudioChannelLayout+SFBExtensions.swift in Sources */,
 				32DBB6F7256D65D40002DEAA /* SFBOggFLACEncoder.mm in Sources */,
-				32D7396B259A771300C0E3F6 /* AudioSubdevice.swift in Sources */,
+				32D7396B259A771300C0E3F6 /* AudioSubDevice.swift in Sources */,
 				32BC09AD2426536D008BB695 /* SFBAudioMetadata+TagLibXiphComment.mm in Sources */,
 				32D7396A259A771300C0E3F6 /* LevelControl.swift in Sources */,
 				321296822449C4B90008DC93 /* SFBWavPackDecoder.m in Sources */,


### PR DESCRIPTION
This better matches the Core Audio naming convention, e.g. kAudioSubDeviceClassID