### PR TITLE
Remove unnecessary pragma once directives

### DIFF
--- a/Metadata/AddAudioPropertiesToDictionary.h
+++ b/Metadata/AddAudioPropertiesToDictionary.h
@@ -1,10 +1,8 @@
 //
-// Copyright (c) 2010 - 2022 Stephen F. Booth <me@sbooth.org>
+// Copyright (c) 2010 - 2024 Stephen F. Booth <me@sbooth.org>
 // Part of https://github.com/sbooth/SFBAudioEngine
 // MIT license
 //
-
-#pragma once
 
 #import <taglib/audioproperties.h>
 

--- a/Metadata/SFBAudioMetadata+TagLibAPETag.h
+++ b/Metadata/SFBAudioMetadata+TagLibAPETag.h
@@ -1,10 +1,8 @@
 //
-// Copyright (c) 2010 - 2022 Stephen F. Booth <me@sbooth.org>
+// Copyright (c) 2010 - 2024 Stephen F. Booth <me@sbooth.org>
 // Part of https://github.com/sbooth/SFBAudioEngine
 // MIT license
 //
-
-#pragma once
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdocumentation"

--- a/Metadata/SFBAudioMetadata+TagLibID3v1Tag.h
+++ b/Metadata/SFBAudioMetadata+TagLibID3v1Tag.h
@@ -1,10 +1,8 @@
 //
-// Copyright (c) 2010 - 2022 Stephen F. Booth <me@sbooth.org>
+// Copyright (c) 2010 - 2024 Stephen F. Booth <me@sbooth.org>
 // Part of https://github.com/sbooth/SFBAudioEngine
 // MIT license
 //
-
-#pragma once
 
 // Ignore warnings about TagLib::ID3v1::StringHandler virtual functions but non-virtual dtor
 

--- a/Metadata/SFBAudioMetadata+TagLibID3v2Tag.h
+++ b/Metadata/SFBAudioMetadata+TagLibID3v2Tag.h
@@ -1,10 +1,8 @@
 //
-// Copyright (c) 2010 - 2022 Stephen F. Booth <me@sbooth.org>
+// Copyright (c) 2010 - 2024 Stephen F. Booth <me@sbooth.org>
 // Part of https://github.com/sbooth/SFBAudioEngine
 // MIT license
 //
-
-#pragma once
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdocumentation"

--- a/Metadata/SFBAudioMetadata+TagLibMP4Tag.h
+++ b/Metadata/SFBAudioMetadata+TagLibMP4Tag.h
@@ -1,10 +1,8 @@
 //
-// Copyright (c) 2010 - 2022 Stephen F. Booth <me@sbooth.org>
+// Copyright (c) 2010 - 2024 Stephen F. Booth <me@sbooth.org>
 // Part of https://github.com/sbooth/SFBAudioEngine
 // MIT license
 //
-
-#pragma once
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdocumentation"

--- a/Metadata/SFBAudioMetadata+TagLibTag.h
+++ b/Metadata/SFBAudioMetadata+TagLibTag.h
@@ -1,10 +1,8 @@
 //
-// Copyright (c) 2010 - 2022 Stephen F. Booth <me@sbooth.org>
+// Copyright (c) 2010 - 2024 Stephen F. Booth <me@sbooth.org>
 // Part of https://github.com/sbooth/SFBAudioEngine
 // MIT license
 //
-
-#pragma once
 
 #import <taglib/tag.h>
 

--- a/Metadata/SFBAudioMetadata+TagLibXiphComment.h
+++ b/Metadata/SFBAudioMetadata+TagLibXiphComment.h
@@ -1,10 +1,8 @@
 //
-// Copyright (c) 2010 - 2023 Stephen F. Booth <me@sbooth.org>
+// Copyright (c) 2010 - 2024 Stephen F. Booth <me@sbooth.org>
 // Part of https://github.com/sbooth/SFBAudioEngine
 // MIT license
 //
-
-#pragma once
 
 #import <memory>
 

--- a/Metadata/TagLibStringUtilities.h
+++ b/Metadata/TagLibStringUtilities.h
@@ -1,10 +1,8 @@
 //
-// Copyright (c) 2010 - 2021 Stephen F. Booth <me@sbooth.org>
+// Copyright (c) 2010 - 2024 Stephen F. Booth <me@sbooth.org>
 // Part of https://github.com/sbooth/SFBAudioEngine
 // MIT license
 //
-
-#pragma once
 
 #import <Foundation/Foundation.h>
 

--- a/Player/SFBTimeUtilities.hpp
+++ b/Player/SFBTimeUtilities.hpp
@@ -4,8 +4,6 @@
 // MIT license
 //
 
-#pragma once
-
 //#import <ctime>
 #import <mach/mach_time.h>
 

--- a/SFBAudioEngine.h
+++ b/SFBAudioEngine.h
@@ -4,8 +4,6 @@
 // MIT license
 //
 
-#pragma once
-
 #import <Foundation/Foundation.h>
 
 /// Project version number for SFBAudioEngine.

--- a/SFBAudioEngineTypes.h
+++ b/SFBAudioEngineTypes.h
@@ -1,10 +1,8 @@
 //
-// Copyright (c) 2006 - 2023 Stephen F. Booth <me@sbooth.org>
+// Copyright (c) 2006 - 2024 Stephen F. Booth <me@sbooth.org>
 // Part of https://github.com/sbooth/SFBAudioEngine
 // MIT license
 //
-
-#pragma once
 
 #import <CoreAudioTypes/CoreAudioTypes.h>
 
@@ -31,7 +29,7 @@ CF_ENUM(AudioFormatID) {
 	/// Ogg Vorbis
 	kSFBAudioFormatVorbis 			CF_SWIFT_NAME(vorbis) 			= 'VORB',
 	/// WavPack
-	kSFBAudioFormatWavPack 			CF_SWIFT_NAME(wavPack) 			= 'WV  '
+	kSFBAudioFormatWavPack 			CF_SWIFT_NAME(wavPack) 			= 'WV  ',
 };
 
 #pragma mark - DSD Constants
@@ -57,7 +55,7 @@ CF_ENUM(uint32_t) {
 	/// Quad-rate DSD (DSD256) based on 48,000 Hz
 	kSFBSampleRateDSD256Variant 	CF_SWIFT_NAME(dsd256SampleRateVariant) 		= 12288000,
 	/// Octuple-rate DSD (DSD512) based on 48,000 Hz
-	kSFBSampleRateDSD512Variant 	CF_SWIFT_NAME(dsd512SampleRateVariant) 		= 24576000
+	kSFBSampleRateDSD512Variant 	CF_SWIFT_NAME(dsd512SampleRateVariant) 		= 24576000,
 };
 
 // A DSD packet in this context is 8 one-bit samples (a single channel byte) grouped into
@@ -90,7 +88,7 @@ NS_ENUM(AVAudioFramePosition) {
 	/// Value representing an invalid or unknown audio packet position
 	SFBUnknownPacketPosition 	NS_SWIFT_NAME(unknownPacketPosition) 	= -1,
 	/// Value representing an invalid or unknown audio packet count
-	SFBUnknownPacketCount 		NS_SWIFT_NAME(unknownPacketCount) 		= -1
+	SFBUnknownPacketCount 		NS_SWIFT_NAME(unknownPacketCount) 		= -1,
 };
 
 #endif /* __OBJC__ */

--- a/Utilities/SFBCStringForOSType.h
+++ b/Utilities/SFBCStringForOSType.h
@@ -1,10 +1,8 @@
 //
-// Copyright (c) 2011 - 2021 Stephen F. Booth <me@sbooth.org>
+// Copyright (c) 2011 - 2024 Stephen F. Booth <me@sbooth.org>
 // Part of https://github.com/sbooth/SFBAudioEngine
 // MIT license
 //
-
-#pragma once
 
 /*! @file SFBCStringForOSType.h @brief OSType to const char [] conversion */
 


### PR DESCRIPTION
They are not needed since `#import` is used for includes.