### PR TITLE
Fix warning about conformance of imported type

### DIFF
--- a/Sources/SFBAudioEngine/SFBAudioPlayer.swift
+++ b/Sources/SFBAudioEngine/SFBAudioPlayer.swift
@@ -66,7 +66,7 @@ extension AudioPlayer {
 	}
 }
 
-extension AudioPlayer.PlaybackState: CustomDebugStringConvertible {
+extension AudioPlayer.PlaybackState: @retroactive CustomDebugStringConvertible {
 	// A textual representation of this instance, suitable for debugging.
 	public var debugDescription: String {
 		switch self {


### PR DESCRIPTION
Another option is just to remove `CustomDebugStringConvertible` conformance from `AudioPlayer.PlaybackState`.