### PR TITLE
Replace use of `CoreServices` with `UniformTypeIdentifiers`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -90,7 +90,7 @@ let package = Package(
 				.linkedFramework("Accelerate"),
 				.linkedFramework("AudioToolbox"),
 				.linkedFramework("AVFAudio"),
-				.linkedFramework("CoreAudioTypes"),
+//				.linkedFramework("CoreAudioTypes"),
 				.linkedFramework("Foundation"),
 				.linkedFramework("ImageIO"),
 				.linkedFramework("UniformTypeIdentifiers"),

--- a/Package.swift
+++ b/Package.swift
@@ -87,9 +87,13 @@ let package = Package(
 				.headerSearchPath("Conversion"),
 			],
 			linkerSettings: [
-				.linkedFramework("CoreServices"),
-				.linkedFramework("Foundation"),
+				.linkedFramework("Accelerate"),
+				.linkedFramework("AudioToolbox"),
 				.linkedFramework("AVFAudio"),
+				.linkedFramework("CoreAudioTypes"),
+				.linkedFramework("Foundation"),
+				.linkedFramework("ImageIO"),
+				.linkedFramework("UniformTypeIdentifiers"),
 			]),
 		.target(
 			name: "SFBAudioEngine",

--- a/Sources/CSFBAudioEngine/Metadata/SFBAudioMetadata+TagLibID3v2Tag.mm
+++ b/Sources/CSFBAudioEngine/Metadata/SFBAudioMetadata+TagLibID3v2Tag.mm
@@ -4,8 +4,8 @@
 // MIT license
 //
 
-#import <CoreServices/CoreServices.h>
 #import <ImageIO/ImageIO.h>
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 
 #import <SFBCFWrapper.hpp>
 
@@ -558,9 +558,11 @@ void SFB::Audio::SetID3v2TagFromMetadata(SFBAudioMetadata *metadata, TagLib::ID3
 			TagLib::ID3v2::AttachedPictureFrame *frame = new TagLib::ID3v2::AttachedPictureFrame;
 
 			// Convert the image's UTI into a MIME type
-			NSString *mimeType = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass(CGImageSourceGetType(imageSource), kUTTagClassMIMEType);
-			if(mimeType)
-				frame->setMimeType(TagLib::StringFromNSString(mimeType));
+			if(CFStringRef typeIdentifier = CGImageSourceGetType(imageSource); typeIdentifier) {
+				UTType *type = [UTType typeWithIdentifier:(__bridge NSString *)typeIdentifier];
+				if(NSString *mimeType = [type preferredMIMEType]; mimeType)
+					frame->setMimeType(TagLib::StringFromNSString(mimeType));
+			}
 
 			frame->setPicture(TagLib::ByteVector(static_cast<const char *>(attachedPicture.imageData.bytes), static_cast<unsigned int>(attachedPicture.imageData.length)));
 			frame->setType((TagLib::ID3v2::AttachedPictureFrame::Type)attachedPicture.pictureType);

--- a/Sources/CSFBAudioEngine/Metadata/SFBAudioMetadata+TagLibMP4Tag.mm
+++ b/Sources/CSFBAudioEngine/Metadata/SFBAudioMetadata+TagLibMP4Tag.mm
@@ -6,8 +6,8 @@
 
 #import <cstdio>
 
-#import <CoreServices/CoreServices.h>
 #import <ImageIO/ImageIO.h>
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 
 #import <SFBCFWrapper.hpp>
 
@@ -239,17 +239,18 @@ void SFB::Audio::SetMP4TagFromMetadata(SFBAudioMetadata *metadata, TagLib::MP4::
 			if(!imageSource)
 				continue;
 
-			// Convert the image's UTI into a MIME type
-			NSString *mimeType = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass(CGImageSourceGetType(imageSource), kUTTagClassMIMEType);
 			auto type = TagLib::MP4::CoverArt::CoverArt::Unknown;
-			if(mimeType) {
-				if(UTTypeEqual(kUTTypeBMP, (__bridge CFStringRef)mimeType))
+
+			// Determine the image type
+			if(CFStringRef typeIdentifier = CGImageSourceGetType(imageSource); typeIdentifier) {
+				UTType *utType = [UTType typeWithIdentifier:(__bridge NSString *)typeIdentifier];
+				if([utType conformsToType:UTTypeBMP])
 					type = TagLib::MP4::CoverArt::CoverArt::BMP;
-				else if(UTTypeEqual(kUTTypePNG, (__bridge CFStringRef)mimeType))
+				else if([utType conformsToType:UTTypePNG])
 					type = TagLib::MP4::CoverArt::CoverArt::PNG;
-				else if(UTTypeEqual(kUTTypeGIF, (__bridge CFStringRef)mimeType))
+				else if([utType conformsToType:UTTypeGIF])
 					type = TagLib::MP4::CoverArt::CoverArt::GIF;
-				else if(UTTypeEqual(kUTTypeJPEG, (__bridge CFStringRef)mimeType))
+				else if([utType conformsToType:UTTypeJPEG])
 					type = TagLib::MP4::CoverArt::CoverArt::JPEG;
 			}
 

--- a/Sources/CSFBAudioEngine/Metadata/SFBAudioMetadata+TagLibXiphComment.mm
+++ b/Sources/CSFBAudioEngine/Metadata/SFBAudioMetadata+TagLibXiphComment.mm
@@ -6,8 +6,8 @@
 
 #import <os/log.h>
 
-#import <CoreServices/CoreServices.h>
 #import <ImageIO/ImageIO.h>
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 
 #import <SFBCFWrapper.hpp>
 
@@ -236,9 +236,11 @@ std::unique_ptr<TagLib::FLAC::Picture> SFB::Audio::ConvertAttachedPictureToFLACP
 		picture->setDescription(TagLib::StringFromNSString(attachedPicture.pictureDescription));
 
 	// Convert the image's UTI into a MIME type
-	NSString *mimeType = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass(CGImageSourceGetType(imageSource), kUTTagClassMIMEType);
-	if(mimeType)
-		picture->setMimeType(TagLib::StringFromNSString(mimeType));
+	if(CFStringRef typeIdentifier = CGImageSourceGetType(imageSource); typeIdentifier) {
+		UTType *type = [UTType typeWithIdentifier:(__bridge NSString *)typeIdentifier];
+		if(NSString *mimeType = [type preferredMIMEType]; mimeType)
+			picture->setMimeType(TagLib::StringFromNSString(mimeType));
+	}
 
 	// Flesh out the height, width, and depth
 	NSDictionary *imagePropertiesDictionary = (__bridge_transfer NSDictionary *)CGImageSourceCopyPropertiesAtIndex(imageSource, 0, nullptr);


### PR DESCRIPTION
This gets rid of some deprecation warnings.