### PR TITLE
Update clang diagnostics for C++20

### DIFF
--- a/Sources/CSFBAudioEngine/Analysis/SFBReplayGainAnalyzer.m
+++ b/Sources/CSFBAudioEngine/Analysis/SFBReplayGainAnalyzer.m
@@ -136,9 +136,6 @@ struct ReplayGainFilter {
 	float AButter [BUTTER_ORDER + 1];
 };
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wimplicit-float-conversion"
-
 static const struct ReplayGainFilter sReplayGainFilters [] = {
 
 	{
@@ -247,8 +244,6 @@ static const struct ReplayGainFilter sReplayGainFilters [] = {
 	},
 
 };
-
-#pragma clang diagnostic pop
 
 /* When calling this procedure, make sure that ip[-order] and op[-order] point to real data! */
 

--- a/Sources/CSFBAudioEngine/Decoders/SFBCoreAudioDecoder.mm
+++ b/Sources/CSFBAudioEngine/Decoders/SFBCoreAudioDecoder.mm
@@ -314,7 +314,10 @@ SInt64 get_size_callback(void *inClientData)
 		AudioStreamBasicDescription asbd{};
 
 		asbd.mFormatID			= kAudioFormatLinearPCM;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-anon-enum-enum-conversion"
 		asbd.mFormatFlags		= kAudioFormatFlagsNativeEndian | kAudioFormatFlagIsSignedInteger;
+#pragma clang diagnostic pop
 
 		asbd.mSampleRate		= format.mSampleRate;
 		asbd.mChannelsPerFrame	= format.mChannelsPerFrame;

--- a/Sources/CSFBAudioEngine/Decoders/SFBFLACDecoder.mm
+++ b/Sources/CSFBAudioEngine/Decoders/SFBFLACDecoder.mm
@@ -243,7 +243,10 @@ void error_callback(const FLAC__StreamDecoder *decoder, FLAC__StreamDecoderError
 	AudioStreamBasicDescription processingStreamDescription{};
 
 	processingStreamDescription.mFormatID			= kAudioFormatLinearPCM;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-anon-enum-enum-conversion"
 	processingStreamDescription.mFormatFlags		= kAudioFormatFlagsNativeEndian | kAudioFormatFlagIsSignedInteger | kAudioFormatFlagIsNonInterleaved;
+#pragma clang diagnostic pop
 
 	processingStreamDescription.mSampleRate			= _streamInfo.sample_rate;
 	processingStreamDescription.mChannelsPerFrame	= _streamInfo.channels;

--- a/Sources/CSFBAudioEngine/Decoders/SFBMonkeysAudioDecoder.mm
+++ b/Sources/CSFBAudioEngine/Decoders/SFBMonkeysAudioDecoder.mm
@@ -267,7 +267,10 @@ private:
 	AudioStreamBasicDescription processingStreamDescription{};
 
 	processingStreamDescription.mFormatID			= kAudioFormatLinearPCM;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-anon-enum-enum-conversion"
 	processingStreamDescription.mFormatFlags		= kAudioFormatFlagIsSignedInteger | kAudioFormatFlagsNativeEndian | kAudioFormatFlagIsPacked;
+#pragma clang diagnostic pop
 
 	processingStreamDescription.mBitsPerChannel		= static_cast<UInt32>(_decompressor->GetInfo(APE::IAPEDecompress::APE_INFO_BITS_PER_SAMPLE));
 	processingStreamDescription.mSampleRate			= _decompressor->GetInfo(APE::IAPEDecompress::APE_INFO_SAMPLE_RATE);

--- a/Sources/CSFBAudioEngine/Decoders/SFBTrueAudioDecoder.mm
+++ b/Sources/CSFBAudioEngine/Decoders/SFBTrueAudioDecoder.mm
@@ -154,7 +154,10 @@ TTAint64 seek_callback(struct _tag_TTA_io_callback *io, TTAint64 offset)
 	AudioStreamBasicDescription processingStreamDescription{};
 
 	processingStreamDescription.mFormatID			= kAudioFormatLinearPCM;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-anon-enum-enum-conversion"
 	processingStreamDescription.mFormatFlags		= kAudioFormatFlagsNativeEndian | kAudioFormatFlagIsSignedInteger;
+#pragma clang diagnostic pop
 
 	processingStreamDescription.mSampleRate			= streamInfo.sps;
 	processingStreamDescription.mChannelsPerFrame	= streamInfo.nch;

--- a/Sources/CSFBAudioEngine/Encoders/SFBCoreAudioEncoder.mm
+++ b/Sources/CSFBAudioEngine/Encoders/SFBCoreAudioEncoder.mm
@@ -4,6 +4,7 @@
 // MIT license
 //
 
+#import <algorithm>
 #import <vector>
 
 #import <os/log.h>

--- a/Sources/CSFBAudioEngine/Encoders/SFBFLACEncoder.mm
+++ b/Sources/CSFBAudioEngine/Encoders/SFBFLACEncoder.mm
@@ -153,7 +153,10 @@ void metadata_callback(const FLAC__StreamEncoder *encoder, const FLAC__StreamMet
 	AudioStreamBasicDescription streamDescription{};
 
 	streamDescription.mFormatID				= kAudioFormatLinearPCM;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-anon-enum-enum-conversion"
 	streamDescription.mFormatFlags			= kAudioFormatFlagsNativeEndian | kAudioFormatFlagIsSignedInteger;
+#pragma clang diagnostic pop
 
 	streamDescription.mSampleRate			= sourceFormat.sampleRate;
 	streamDescription.mChannelsPerFrame		= sourceFormat.channelCount;

--- a/Sources/CSFBAudioEngine/Encoders/SFBMonkeysAudioEncoder.mm
+++ b/Sources/CSFBAudioEngine/Encoders/SFBMonkeysAudioEncoder.mm
@@ -219,7 +219,10 @@ private:
 	AudioStreamBasicDescription streamDescription{};
 
 	streamDescription.mFormatID				= kAudioFormatLinearPCM;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-anon-enum-enum-conversion"
 	streamDescription.mFormatFlags			= kAudioFormatFlagsNativeEndian | kAudioFormatFlagIsSignedInteger | kAudioFormatFlagIsPacked;
+#pragma clang diagnostic pop
 
 	streamDescription.mSampleRate			= wve.nSamplesPerSec;
 	streamDescription.mChannelsPerFrame		= wve.nChannels;

--- a/Sources/CSFBAudioEngine/Encoders/SFBOggFLACEncoder.mm
+++ b/Sources/CSFBAudioEngine/Encoders/SFBOggFLACEncoder.mm
@@ -169,7 +169,10 @@ void metadata_callback(const FLAC__StreamEncoder *encoder, const FLAC__StreamMet
 	AudioStreamBasicDescription streamDescription{};
 
 	streamDescription.mFormatID				= kAudioFormatLinearPCM;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-anon-enum-enum-conversion"
 	streamDescription.mFormatFlags			= kAudioFormatFlagsNativeEndian | kAudioFormatFlagIsSignedInteger;
+#pragma clang diagnostic pop
 
 	streamDescription.mSampleRate			= sourceFormat.sampleRate;
 	streamDescription.mChannelsPerFrame		= sourceFormat.channelCount;

--- a/Sources/CSFBAudioEngine/Encoders/SFBTrueAudioEncoder.mm
+++ b/Sources/CSFBAudioEngine/Encoders/SFBTrueAudioEncoder.mm
@@ -90,7 +90,10 @@ TTAint64 seek_callback(struct _tag_TTA_io_callback *io, TTAint64 offset)
 	AudioStreamBasicDescription streamDescription{};
 
 	streamDescription.mFormatID				= kAudioFormatLinearPCM;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-anon-enum-enum-conversion"
 	streamDescription.mFormatFlags			= kAudioFormatFlagsNativeEndian | kAudioFormatFlagIsSignedInteger;
+#pragma clang diagnostic pop
 
 	streamDescription.mSampleRate			= sourceFormat.sampleRate;
 	streamDescription.mChannelsPerFrame		= sourceFormat.channelCount;

--- a/Sources/CSFBAudioEngine/Metadata/SFBAIFFFile.mm
+++ b/Sources/CSFBAudioEngine/Metadata/SFBAIFFFile.mm
@@ -6,13 +6,8 @@
 
 #import <memory>
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdocumentation"
-
 #import <taglib/aifffile.h>
 #import <taglib/tfilestream.h>
-
-#pragma clang diagnostic pop
 
 #import "SFBAIFFFile.h"
 

--- a/Sources/CSFBAudioEngine/Metadata/SFBAudioMetadata+TagLibAPETag.h
+++ b/Sources/CSFBAudioEngine/Metadata/SFBAudioMetadata+TagLibAPETag.h
@@ -4,12 +4,7 @@
 // MIT license
 //
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdocumentation"
-
 #import <taglib/apetag.h>
-
-#pragma clang diagnostic pop
 
 #import "SFBAudioMetadata.h"
 

--- a/Sources/CSFBAudioEngine/Metadata/SFBAudioMetadata+TagLibID3v1Tag.h
+++ b/Sources/CSFBAudioEngine/Metadata/SFBAudioMetadata+TagLibID3v1Tag.h
@@ -4,14 +4,7 @@
 // MIT license
 //
 
-// Ignore warnings about TagLib::ID3v1::StringHandler virtual functions but non-virtual dtor
-
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wnon-virtual-dtor"
-
 #import <taglib/id3v1tag.h>
-
-#pragma clang diagnostic pop
 
 #import "SFBAudioMetadata.h"
 

--- a/Sources/CSFBAudioEngine/Metadata/SFBAudioMetadata+TagLibID3v2Tag.h
+++ b/Sources/CSFBAudioEngine/Metadata/SFBAudioMetadata+TagLibID3v2Tag.h
@@ -4,12 +4,7 @@
 // MIT license
 //
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdocumentation"
-
 #import <taglib/id3v2tag.h>
-
-#pragma clang diagnostic pop
 
 #import "SFBAudioMetadata.h"
 

--- a/Sources/CSFBAudioEngine/Metadata/SFBAudioMetadata+TagLibID3v2Tag.mm
+++ b/Sources/CSFBAudioEngine/Metadata/SFBAudioMetadata+TagLibID3v2Tag.mm
@@ -9,17 +9,12 @@
 #import <ImageIO/ImageIO.h>
 #import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdocumentation"
-
 #import <taglib/attachedpictureframe.h>
 #import <taglib/id3v2frame.h>
 #import <taglib/popularimeterframe.h>
 #import <taglib/relativevolumeframe.h>
 #import <taglib/textidentificationframe.h>
 #import <taglib/unsynchronizedlyricsframe.h>
-
-#pragma clang diagnostic pop
 
 #import "SFBAudioMetadata+TagLibID3v2Tag.h"
 

--- a/Sources/CSFBAudioEngine/Metadata/SFBAudioMetadata+TagLibMP4Tag.h
+++ b/Sources/CSFBAudioEngine/Metadata/SFBAudioMetadata+TagLibMP4Tag.h
@@ -4,13 +4,7 @@
 // MIT license
 //
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdocumentation"
-#pragma clang diagnostic ignored "-Wshadow"
-
 #import <taglib/mp4tag.h>
-
-#pragma clang diagnostic pop
 
 #import "SFBAudioMetadata.h"
 

--- a/Sources/CSFBAudioEngine/Metadata/SFBDSDIFFFile.mm
+++ b/Sources/CSFBAudioEngine/Metadata/SFBDSDIFFFile.mm
@@ -6,13 +6,8 @@
 
 #import <memory>
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdocumentation"
-
 #import <taglib/dsdifffile.h>
 #import <taglib/tfilestream.h>
-
-#pragma clang diagnostic pop
 
 #import "SFBDSDIFFFile.h"
 

--- a/Sources/CSFBAudioEngine/Metadata/SFBDSFFile.mm
+++ b/Sources/CSFBAudioEngine/Metadata/SFBDSFFile.mm
@@ -6,13 +6,8 @@
 
 #import <memory>
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdocumentation"
-
 #import <taglib/dsffile.h>
 #import <taglib/tfilestream.h>
-
-#pragma clang diagnostic pop
 
 #import "SFBDSFFile.h"
 

--- a/Sources/CSFBAudioEngine/Metadata/SFBFLACFile.mm
+++ b/Sources/CSFBAudioEngine/Metadata/SFBFLACFile.mm
@@ -8,13 +8,8 @@
 
 #import <CoreServices/CoreServices.h>
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdocumentation"
-
 #import <taglib/flacfile.h>
 #import <taglib/tfilestream.h>
-
-#pragma clang diagnostic pop
 
 #import "SFBFLACFile.h"
 

--- a/Sources/CSFBAudioEngine/Metadata/SFBMP3File.mm
+++ b/Sources/CSFBAudioEngine/Metadata/SFBMP3File.mm
@@ -6,14 +6,9 @@
 
 #import <memory>
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdocumentation"
-
 #import <taglib/mpegfile.h>
 #import <taglib/tfilestream.h>
 #import <taglib/xingheader.h>
-
-#pragma clang diagnostic pop
 
 #import "SFBMP3File.h"
 

--- a/Sources/CSFBAudioEngine/Metadata/SFBMP4File.mm
+++ b/Sources/CSFBAudioEngine/Metadata/SFBMP4File.mm
@@ -6,14 +6,8 @@
 
 #import <memory>
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdocumentation"
-#pragma clang diagnostic ignored "-Wshadow"
-
 #import <taglib/mp4file.h>
 #import <taglib/tfilestream.h>
-
-#pragma clang diagnostic pop
 
 #import "SFBMP4File.h"
 

--- a/Sources/CSFBAudioEngine/Metadata/SFBMonkeysAudioFile.mm
+++ b/Sources/CSFBAudioEngine/Metadata/SFBMonkeysAudioFile.mm
@@ -6,13 +6,8 @@
 
 #import <memory>
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdocumentation"
-
 #import <taglib/apefile.h>
 #import <taglib/tfilestream.h>
-
-#pragma clang diagnostic pop
 
 #import "SFBMonkeysAudioFile.h"
 

--- a/Sources/CSFBAudioEngine/Metadata/SFBMusepackFile.mm
+++ b/Sources/CSFBAudioEngine/Metadata/SFBMusepackFile.mm
@@ -6,13 +6,8 @@
 
 #import <memory>
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdocumentation"
-
 #import <taglib/mpcfile.h>
 #import <taglib/tfilestream.h>
-
-#pragma clang diagnostic pop
 
 #import "SFBMusepackFile.h"
 

--- a/Sources/CSFBAudioEngine/Metadata/SFBOggFLACFile.mm
+++ b/Sources/CSFBAudioEngine/Metadata/SFBOggFLACFile.mm
@@ -6,13 +6,8 @@
 
 #import <memory>
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdocumentation"
-
 #import <taglib/oggflacfile.h>
 #import <taglib/tfilestream.h>
-
-#pragma clang diagnostic pop
 
 #import "SFBOggFLACFile.h"
 

--- a/Sources/CSFBAudioEngine/Metadata/SFBOggOpusFile.mm
+++ b/Sources/CSFBAudioEngine/Metadata/SFBOggOpusFile.mm
@@ -6,13 +6,8 @@
 
 #import <memory>
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdocumentation"
-
 #import <taglib/opusfile.h>
 #import <taglib/tfilestream.h>
-
-#pragma clang diagnostic pop
 
 #import "SFBOggOpusFile.h"
 

--- a/Sources/CSFBAudioEngine/Metadata/SFBOggSpeexFile.mm
+++ b/Sources/CSFBAudioEngine/Metadata/SFBOggSpeexFile.mm
@@ -6,13 +6,8 @@
 
 #import <memory>
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdocumentation"
-
 #import <taglib/speexfile.h>
 #import <taglib/tfilestream.h>
-
-#pragma clang diagnostic pop
 
 #import "SFBOggSpeexFile.h"
 

--- a/Sources/CSFBAudioEngine/Metadata/SFBOggVorbisFile.mm
+++ b/Sources/CSFBAudioEngine/Metadata/SFBOggVorbisFile.mm
@@ -1,18 +1,13 @@
 //
-// Copyright (c) 2006-2022 Stephen F. Booth <me@sbooth.org>
+// Copyright (c) 2006-2024 Stephen F. Booth <me@sbooth.org>
 // Part of https://github.com/sbooth/SFBAudioEngine
 // MIT license
 //
 
 #import <memory>
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdocumentation"
-
 #import <taglib/tfilestream.h>
 #import <taglib/vorbisfile.h>
-
-#pragma clang diagnostic pop
 
 #import "SFBOggVorbisFile.h"
 

--- a/Sources/CSFBAudioEngine/Metadata/SFBProTrackerModuleFile.mm
+++ b/Sources/CSFBAudioEngine/Metadata/SFBProTrackerModuleFile.mm
@@ -8,12 +8,8 @@
 
 #import <os/log.h>
 
-#pragma clang diagnostic push
-
 #import <taglib/modfile.h>
 #import <taglib/tfilestream.h>
-
-#pragma clang diagnostic pop
 
 #import "SFBProTrackerModuleFile.h"
 

--- a/Sources/CSFBAudioEngine/Metadata/SFBScreamTracker3ModuleFile.mm
+++ b/Sources/CSFBAudioEngine/Metadata/SFBScreamTracker3ModuleFile.mm
@@ -8,12 +8,8 @@
 
 #import <os/log.h>
 
-#pragma clang diagnostic push
-
 #import <taglib/s3mfile.h>
 #import <taglib/tfilestream.h>
-
-#pragma clang diagnostic pop
 
 #import "SFBScreamTracker3ModuleFile.h"
 

--- a/Sources/CSFBAudioEngine/Metadata/SFBTrueAudioFile.mm
+++ b/Sources/CSFBAudioEngine/Metadata/SFBTrueAudioFile.mm
@@ -6,13 +6,8 @@
 
 #import <memory>
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdocumentation"
-
 #import <taglib/tfilestream.h>
 #import <taglib/trueaudiofile.h>
-
-#pragma clang diagnostic pop
 
 #import "SFBTrueAudioFile.h"
 

--- a/Sources/CSFBAudioEngine/Metadata/SFBWAVEFile.mm
+++ b/Sources/CSFBAudioEngine/Metadata/SFBWAVEFile.mm
@@ -6,13 +6,8 @@
 
 #import <memory>
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdocumentation"
-
 #import <taglib/tfilestream.h>
 #import <taglib/wavfile.h>
-
-#pragma clang diagnostic pop
 
 #import "SFBWAVEFile.h"
 

--- a/Sources/CSFBAudioEngine/Metadata/SFBWavPackFile.mm
+++ b/Sources/CSFBAudioEngine/Metadata/SFBWavPackFile.mm
@@ -6,13 +6,8 @@
 
 #import <memory>
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdocumentation"
-
 #import <taglib/tfilestream.h>
 #import <taglib/wavpackfile.h>
-
-#pragma clang diagnostic pop
 
 #import "SFBWavPackFile.h"
 


### PR DESCRIPTION
Remove some unnecessary diagnostics and also ignore:

>Comparison of different enumeration types ('(unnamed enum at /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.1.sdk/System/Library/Frameworks/CoreAudioTypes.framework/Headers/CoreAudioBaseTypes.h:503:1)' and '(unnamed enum at /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.1.sdk/System/Library/Frameworks/CoreAudioTypes.framework/Headers/CoreAudioBaseTypes.h:554:1)') is deprecated