### PR TITLE
Attempt to fix race condition in `~AudioPlayerNode`

### DIFF
--- a/Sources/CSFBAudioEngine/Player/SFBAudioPlayerNode.mm
+++ b/Sources/CSFBAudioEngine/Player/SFBAudioPlayerNode.mm
@@ -637,11 +637,11 @@ public:
 		Stop();
 
 		// Wait for decoding to complete
-		/*const auto timeout =*/ dispatch_group_wait(mDecodingGroup, DISPATCH_TIME_FOREVER);
+		dispatch_group_wait(mDecodingGroup, DISPATCH_TIME_FOREVER);
 
 		// Wait for event processing to complete
 		if(const auto data = dispatch_source_get_data(mEventProcessor); data)
-		/*const auto timeout =*/ dispatch_group_wait(mEventProcessingGroup, DISPATCH_TIME_FOREVER);
+			dispatch_group_wait(mEventProcessingGroup, DISPATCH_TIME_FOREVER);
 
 		// Cancel any further event processing
 		dispatch_source_cancel(mEventProcessor);

--- a/Sources/CSFBAudioEngine/Player/SFBAudioPlayerNode.mm
+++ b/Sources/CSFBAudioEngine/Player/SFBAudioPlayerNode.mm
@@ -640,8 +640,7 @@ public:
 		dispatch_group_wait(mDecodingGroup, DISPATCH_TIME_FOREVER);
 
 		// Wait for event processing to complete
-		if(const auto data = dispatch_source_get_data(mEventProcessor); data)
-			dispatch_group_wait(mEventProcessingGroup, DISPATCH_TIME_FOREVER);
+		dispatch_group_wait(mEventProcessingGroup, DISPATCH_TIME_FOREVER);
 
 		// Cancel any further event processing
 		dispatch_source_cancel(mEventProcessor);

--- a/Sources/CSFBAudioEngine/Player/SFBAudioPlayerNode.mm
+++ b/Sources/CSFBAudioEngine/Player/SFBAudioPlayerNode.mm
@@ -615,15 +615,10 @@ public:
 		}
 
 		dispatch_source_set_event_handler(mEventProcessor, ^{
-			if(dispatch_source_testcancel(mEventProcessor))
-				return;
-
-			dispatch_group_enter(mEventProcessingGroup);
 			ProcessPendingEvents();
-			dispatch_group_leave(mEventProcessingGroup);
 		});
 
-		// Start processing events
+		// Start processing events from the render block
 		dispatch_activate(mEventProcessor);
 	}
 


### PR DESCRIPTION
Fixes #441

This PR attempts to fix the issue by submitting event processing blocks directly to the event queue from the decoding queue instead of through the dispatch source.