### PR TITLE
Set channel layout for source and output formats

### DIFF
--- a/Sources/CSFBAudioEngine/Decoders/SFBDSDIFFDecoder.mm
+++ b/Sources/CSFBAudioEngine/Decoders/SFBDSDIFFDecoder.mm
@@ -804,7 +804,7 @@ static NSError * CreateInvalidDSDIFFFileError(NSURL * url)
 	sourceStreamDescription.mChannelsPerFrame	= channelsChunk->mNumberChannels;
 	sourceStreamDescription.mBitsPerChannel		= 1;
 
-	_sourceFormat = [[AVAudioFormat alloc] initWithStreamDescription:&sourceStreamDescription];
+	_sourceFormat = [[AVAudioFormat alloc] initWithStreamDescription:&sourceStreamDescription channelLayout:channelLayout];
 
 	auto soundDataChunk = std::static_pointer_cast<DSDSoundDataChunk>(chunks->mLocalChunks['DSD ']);
 	if(!soundDataChunk) {

--- a/Sources/CSFBAudioEngine/Decoders/SFBDSFDecoder.m
+++ b/Sources/CSFBAudioEngine/Decoders/SFBDSFDecoder.m
@@ -288,7 +288,7 @@ static void MatrixTransposeNaive(const uint8_t * restrict A, uint8_t * restrict 
 	sourceStreamDescription.mChannelsPerFrame	= (UInt32)channelNum;
 	sourceStreamDescription.mBitsPerChannel		= 1;
 
-	_sourceFormat = [[AVAudioFormat alloc] initWithStreamDescription:&sourceStreamDescription];
+	_sourceFormat = [[AVAudioFormat alloc] initWithStreamDescription:&sourceStreamDescription channelLayout:channelLayout];
 
 	// Metadata chunk is ignored
 

--- a/Sources/CSFBAudioEngine/Decoders/SFBFLACDecoder.mm
+++ b/Sources/CSFBAudioEngine/Decoders/SFBFLACDecoder.mm
@@ -331,7 +331,7 @@ void error_callback(const FLAC__StreamDecoder *decoder, FLAC__StreamDecoderError
 
 	sourceStreamDescription.mFramesPerPacket	= _streamInfo.max_blocksize;
 
-	_sourceFormat = [[AVAudioFormat alloc] initWithStreamDescription:&sourceStreamDescription];
+	_sourceFormat = [[AVAudioFormat alloc] initWithStreamDescription:&sourceStreamDescription channelLayout:channelLayout];
 
 	// Populate codec properties
 	_properties = @{

--- a/Sources/CSFBAudioEngine/Decoders/SFBLibsndfileDecoder.m
+++ b/Sources/CSFBAudioEngine/Decoders/SFBLibsndfileDecoder.m
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2011-2024 Stephen F. Booth <me@sbooth.org>
+// Copyright (c) 2011-2025 Stephen F. Booth <me@sbooth.org>
 // Part of https://github.com/sbooth/SFBAudioEngine
 // MIT license
 //
@@ -388,7 +388,7 @@ static sf_count_t my_sf_vio_tell(void *user_data)
 			break;
 	}
 
-	_sourceFormat = [[AVAudioFormat alloc] initWithStreamDescription:&sourceStreamDescription];
+	_sourceFormat = [[AVAudioFormat alloc] initWithStreamDescription:&sourceStreamDescription channelLayout:channelLayout];
 
 	return YES;
 }

--- a/Sources/CSFBAudioEngine/Decoders/SFBMPEGDecoder.m
+++ b/Sources/CSFBAudioEngine/Decoders/SFBMPEGDecoder.m
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2006-2024 Stephen F. Booth <me@sbooth.org>
+// Copyright (c) 2006-2025 Stephen F. Booth <me@sbooth.org>
 // Part of https://github.com/sbooth/SFBAudioEngine
 // MIT license
 //
@@ -239,7 +239,7 @@ static off_t lseek_callback(void *iohandle, off_t offset, int whence)
 
 	sourceStreamDescription.mFramesPerPacket	= framesPerMPEGFrame;
 
-	_sourceFormat = [[AVAudioFormat alloc] initWithStreamDescription:&sourceStreamDescription];
+	_sourceFormat = [[AVAudioFormat alloc] initWithStreamDescription:&sourceStreamDescription channelLayout:channelLayout];
 
 	if(mpg123_scan(_mpg123) != MPG123_OK) {
 		mpg123_close(_mpg123);

--- a/Sources/CSFBAudioEngine/Decoders/SFBModuleDecoder.m
+++ b/Sources/CSFBAudioEngine/Decoders/SFBModuleDecoder.m
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2011-2024 Stephen F. Booth <me@sbooth.org>
+// Copyright (c) 2011-2025 Stephen F. Booth <me@sbooth.org>
 // Part of https://github.com/sbooth/SFBAudioEngine
 // MIT license
 //
@@ -144,8 +144,8 @@ static dumb_off_t get_size_callback(void *f)
 		return NO;
 
 	// Generate interleaved 2-channel 16-bit output
-	AVAudioChannelLayout *layout = [[AVAudioChannelLayout alloc] initWithLayoutTag:kAudioChannelLayoutTag_Stereo];
-	_processingFormat = [[AVAudioFormat alloc] initWithCommonFormat:AVAudioPCMFormatInt16 sampleRate:DUMB_SAMPLE_RATE interleaved:YES channelLayout:layout];
+	// For mono and stereo the channel layout is assumed
+	_processingFormat = [[AVAudioFormat alloc] initWithCommonFormat:AVAudioPCMFormatInt16 sampleRate:DUMB_SAMPLE_RATE channels:DUMB_CHANNELS interleaved:YES];
 
 	// Set up the source format
 	AudioStreamBasicDescription sourceStreamDescription = {0};

--- a/Sources/CSFBAudioEngine/Decoders/SFBMonkeysAudioDecoder.mm
+++ b/Sources/CSFBAudioEngine/Decoders/SFBMonkeysAudioDecoder.mm
@@ -284,7 +284,7 @@ private:
 	sourceStreamDescription.mSampleRate			= _decompressor->GetInfo(APE::IAPEDecompress::APE_INFO_SAMPLE_RATE);
 	sourceStreamDescription.mChannelsPerFrame	= static_cast<UInt32>(_decompressor->GetInfo(APE::IAPEDecompress::APE_INFO_CHANNELS));
 
-	_sourceFormat = [[AVAudioFormat alloc] initWithStreamDescription:&sourceStreamDescription];
+	_sourceFormat = [[AVAudioFormat alloc] initWithStreamDescription:&sourceStreamDescription channelLayout:channelLayout];
 
 	// Populate codec properties
 	_properties = @{

--- a/Sources/CSFBAudioEngine/Decoders/SFBMusepackDecoder.m
+++ b/Sources/CSFBAudioEngine/Decoders/SFBMusepackDecoder.m
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2006-2024 Stephen F. Booth <me@sbooth.org>
+// Copyright (c) 2006-2025 Stephen F. Booth <me@sbooth.org>
 // Part of https://github.com/sbooth/SFBAudioEngine
 // MIT license
 //
@@ -206,7 +206,7 @@ static mpc_bool_t canseek_callback(mpc_reader *p_reader)
 
 	sourceStreamDescription.mFramesPerPacket	= (1 << streaminfo.block_pwr);
 
-	_sourceFormat = [[AVAudioFormat alloc] initWithStreamDescription:&sourceStreamDescription];
+	_sourceFormat = [[AVAudioFormat alloc] initWithStreamDescription:&sourceStreamDescription channelLayout:channelLayout];
 
 	// Populate codec properties
 	_properties = @{

--- a/Sources/CSFBAudioEngine/Decoders/SFBOggOpusDecoder.m
+++ b/Sources/CSFBAudioEngine/Decoders/SFBOggOpusDecoder.m
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2006-2024 Stephen F. Booth <me@sbooth.org>
+// Copyright (c) 2006-2025 Stephen F. Booth <me@sbooth.org>
 // Part of https://github.com/sbooth/SFBAudioEngine
 // MIT license
 //
@@ -196,7 +196,7 @@ static opus_int64 tell_callback(void *stream)
 	sourceStreamDescription.mSampleRate			= header->input_sample_rate;
 	sourceStreamDescription.mChannelsPerFrame	= (UInt32)header->channel_count;
 
-	_sourceFormat = [[AVAudioFormat alloc] initWithStreamDescription:&sourceStreamDescription];
+	_sourceFormat = [[AVAudioFormat alloc] initWithStreamDescription:&sourceStreamDescription channelLayout:channelLayout];
 
 	// Populate codec properties
 	_properties = @{

--- a/Sources/CSFBAudioEngine/Decoders/SFBOggSpeexDecoder.m
+++ b/Sources/CSFBAudioEngine/Decoders/SFBOggSpeexDecoder.m
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2011-2024 Stephen F. Booth <me@sbooth.org>
+// Copyright (c) 2011-2025 Stephen F. Booth <me@sbooth.org>
 // Part of https://github.com/sbooth/SFBAudioEngine
 // MIT license
 //

--- a/Sources/CSFBAudioEngine/Decoders/SFBOggVorbisDecoder.m
+++ b/Sources/CSFBAudioEngine/Decoders/SFBOggVorbisDecoder.m
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2006-2024 Stephen F. Booth <me@sbooth.org>
+// Copyright (c) 2006-2025 Stephen F. Booth <me@sbooth.org>
 // Part of https://github.com/sbooth/SFBAudioEngine
 // MIT license
 //
@@ -200,7 +200,7 @@ static long tell_func_callback(void *datasource)
 	sourceStreamDescription.mSampleRate			= ovInfo->rate;
 	sourceStreamDescription.mChannelsPerFrame	= (UInt32)ovInfo->channels;
 
-	_sourceFormat = [[AVAudioFormat alloc] initWithStreamDescription:&sourceStreamDescription];
+	_sourceFormat = [[AVAudioFormat alloc] initWithStreamDescription:&sourceStreamDescription channelLayout:channelLayout];
 
 	// Populate codec properties
 	_properties = @{

--- a/Sources/CSFBAudioEngine/Decoders/SFBShortenDecoder.mm
+++ b/Sources/CSFBAudioEngine/Decoders/SFBShortenDecoder.mm
@@ -564,7 +564,7 @@ constexpr int16_t ALawToLinear(uint8_t alaw) noexcept
 
 	sourceStreamDescription.mFramesPerPacket	= static_cast<UInt32>(_blocksize);
 
-	_sourceFormat = [[AVAudioFormat alloc] initWithStreamDescription:&sourceStreamDescription];
+	_sourceFormat = [[AVAudioFormat alloc] initWithStreamDescription:&sourceStreamDescription channelLayout:channelLayout];
 
 	// Populate codec properties
 	_properties = @{

--- a/Sources/CSFBAudioEngine/Decoders/SFBTrueAudioDecoder.mm
+++ b/Sources/CSFBAudioEngine/Decoders/SFBTrueAudioDecoder.mm
@@ -212,7 +212,7 @@ TTAint64 seek_callback(struct _tag_TTA_io_callback *io, TTAint64 offset)
 	sourceStreamDescription.mChannelsPerFrame	= streamInfo.nch;
 	sourceStreamDescription.mBitsPerChannel		= streamInfo.bps;
 
-	_sourceFormat = [[AVAudioFormat alloc] initWithStreamDescription:&sourceStreamDescription];
+	_sourceFormat = [[AVAudioFormat alloc] initWithStreamDescription:&sourceStreamDescription channelLayout:channelLayout];
 
 	// Populate codec properties
 	_properties = @{

--- a/Sources/CSFBAudioEngine/Decoders/SFBWavPackDecoder.m
+++ b/Sources/CSFBAudioEngine/Decoders/SFBWavPackDecoder.m
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2011-2024 Stephen F. Booth <me@sbooth.org>
+// Copyright (c) 2011-2025 Stephen F. Booth <me@sbooth.org>
 // Part of https://github.com/sbooth/SFBAudioEngine
 // MIT license
 //
@@ -345,7 +345,7 @@ static int can_seek_callback(void *id)
 	sourceStreamDescription.mBitsPerChannel		= (UInt32)WavpackGetBitsPerSample(_wpc);
 	sourceStreamDescription.mBytesPerPacket		= (UInt32)WavpackGetBytesPerSample(_wpc);
 
-	_sourceFormat = [[AVAudioFormat alloc] initWithStreamDescription:&sourceStreamDescription];
+	_sourceFormat = [[AVAudioFormat alloc] initWithStreamDescription:&sourceStreamDescription channelLayout:channelLayout];
 
 	// Populate codec properties
 	_properties = @{

--- a/Sources/CSFBAudioEngine/Encoders/SFBCoreAudioEncoder.mm
+++ b/Sources/CSFBAudioEngine/Encoders/SFBCoreAudioEncoder.mm
@@ -411,7 +411,7 @@ OSStatus my_AudioFile_SetSizeProc(void *inClientData, SInt64 inSize)
 			default:	format.mFormatFlags = kAppleLosslessFormatFlag_16BitSourceData;		break;
 		}
 	}
-	_outputFormat = [[AVAudioFormat alloc] initWithStreamDescription:&format];
+	_outputFormat = [[AVAudioFormat alloc] initWithStreamDescription:&format channelLayout:_processingFormat.channelLayout];
 
 	AudioFileID audioFile;
 	auto result = AudioFileInitializeWithCallbacks((__bridge void *)self, my_AudioFile_ReadProc, my_AudioFile_WriteProc, my_AudioFile_GetSizeProc, my_AudioFile_SetSizeProc, fileType, &format, 0, &audioFile);

--- a/Sources/CSFBAudioEngine/Encoders/SFBFLACEncoder.mm
+++ b/Sources/CSFBAudioEngine/Encoders/SFBFLACEncoder.mm
@@ -373,7 +373,7 @@ void metadata_callback(const FLAC__StreamEncoder *encoder, const FLAC__StreamMet
 			break;
 	}
 	outputStreamDescription.mFramesPerPacket	= FLAC__stream_encoder_get_blocksize(flac.get());
-	_outputFormat = [[AVAudioFormat alloc] initWithStreamDescription:&outputStreamDescription];
+	_outputFormat = [[AVAudioFormat alloc] initWithStreamDescription:&outputStreamDescription channelLayout:_processingFormat.channelLayout];
 
 	_flac = std::move(flac);
 	_seektable = std::move(seektable);

--- a/Sources/CSFBAudioEngine/Encoders/SFBMonkeysAudioEncoder.mm
+++ b/Sources/CSFBAudioEngine/Encoders/SFBMonkeysAudioEncoder.mm
@@ -300,7 +300,7 @@ private:
 	outputStreamDescription.mBitsPerChannel		= wve.wBitsPerSample;
 	outputStreamDescription.mSampleRate			= wve.nSamplesPerSec;
 	outputStreamDescription.mChannelsPerFrame	= wve.nChannels;
-	_outputFormat = [[AVAudioFormat alloc] initWithStreamDescription:&outputStreamDescription];
+	_outputFormat = [[AVAudioFormat alloc] initWithStreamDescription:&outputStreamDescription channelLayout:_processingFormat.channelLayout];
 
 	return YES;
 }

--- a/Sources/CSFBAudioEngine/Encoders/SFBOggOpusEncoder.mm
+++ b/Sources/CSFBAudioEngine/Encoders/SFBOggOpusEncoder.mm
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020-2024 Stephen F. Booth <me@sbooth.org>
+// Copyright (c) 2020-2025 Stephen F. Booth <me@sbooth.org>
 // Part of https://github.com/sbooth/SFBAudioEngine
 // MIT license
 //
@@ -309,7 +309,7 @@ int close_callback(void *user_data)
 	outputStreamDescription.mFormatID			= kAudioFormatOpus;
 	outputStreamDescription.mSampleRate			= _processingFormat.sampleRate;
 	outputStreamDescription.mChannelsPerFrame	= _processingFormat.channelCount;
-	_outputFormat = [[AVAudioFormat alloc] initWithStreamDescription:&outputStreamDescription];
+	_outputFormat = [[AVAudioFormat alloc] initWithStreamDescription:&outputStreamDescription channelLayout:_processingFormat.channelLayout];
 
 	_enc = std::move(enc);
 	_comments = std::move(comments);

--- a/Sources/CSFBAudioEngine/Encoders/SFBOggVorbisEncoder.m
+++ b/Sources/CSFBAudioEngine/Encoders/SFBOggVorbisEncoder.m
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020-2024 Stephen F. Booth <me@sbooth.org>
+// Copyright (c) 2020-2025 Stephen F. Booth <me@sbooth.org>
 // Part of https://github.com/sbooth/SFBAudioEngine
 // MIT license
 //
@@ -196,7 +196,7 @@ SFBAudioEncodingSettingsKey const SFBAudioEncodingSettingsKeyVorbisMaxBitrate = 
 	outputStreamDescription.mFormatID			= kSFBAudioFormatVorbis;
 	outputStreamDescription.mSampleRate			= _processingFormat.sampleRate;
 	outputStreamDescription.mChannelsPerFrame	= _processingFormat.channelCount;
-	_outputFormat = [[AVAudioFormat alloc] initWithStreamDescription:&outputStreamDescription];
+	_outputFormat = [[AVAudioFormat alloc] initWithStreamDescription:&outputStreamDescription channelLayout:_processingFormat.channelLayout];
 
 	_isOpen = YES;
 

--- a/Sources/CSFBAudioEngine/Encoders/SFBTrueAudioEncoder.mm
+++ b/Sources/CSFBAudioEngine/Encoders/SFBTrueAudioEncoder.mm
@@ -160,7 +160,7 @@ TTAint64 seek_callback(struct _tag_TTA_io_callback *io, TTAint64 offset)
 	outputStreamDescription.mBitsPerChannel		= _processingFormat.streamDescription->mBitsPerChannel;
 	outputStreamDescription.mSampleRate			= _processingFormat.sampleRate;
 	outputStreamDescription.mChannelsPerFrame	= _processingFormat.channelCount;
-	_outputFormat = [[AVAudioFormat alloc] initWithStreamDescription:&outputStreamDescription];
+	_outputFormat = [[AVAudioFormat alloc] initWithStreamDescription:&outputStreamDescription channelLayout:_processingFormat.channelLayout];
 
 	return YES;
 }

--- a/Sources/CSFBAudioEngine/Encoders/SFBWavPackEncoder.m
+++ b/Sources/CSFBAudioEngine/Encoders/SFBWavPackEncoder.m
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020-2024 Stephen F. Booth <me@sbooth.org>
+// Copyright (c) 2020-2025 Stephen F. Booth <me@sbooth.org>
 // Part of https://github.com/sbooth/SFBAudioEngine
 // MIT license
 //
@@ -195,7 +195,7 @@ static int wavpack_block_output(void *id, void *data, int32_t bcount)
 	outputStreamDescription.mBitsPerChannel		= _processingFormat.streamDescription->mBitsPerChannel;
 	outputStreamDescription.mSampleRate			= _processingFormat.sampleRate;
 	outputStreamDescription.mChannelsPerFrame	= _processingFormat.channelCount;
-	_outputFormat = [[AVAudioFormat alloc] initWithStreamDescription:&outputStreamDescription];
+	_outputFormat = [[AVAudioFormat alloc] initWithStreamDescription:&outputStreamDescription channelLayout:_processingFormat.channelLayout];
 
 	return YES;
 }


### PR DESCRIPTION
For more than two channels `AVAudioFormat` initialization fails without a channel layout

Fixes #461 