### PR TITLE
SFBAudioConverter: abort on decoding error

### DIFF
--- a/Sources/CSFBAudioEngine/Conversion/SFBAudioExporter.m
+++ b/Sources/CSFBAudioEngine/Conversion/SFBAudioExporter.m
@@ -73,43 +73,37 @@ NSErrorDomain const SFBAudioExporterErrorDomain = @"org.sbooth.AudioEngine.Audio
 	AVAudioPCMBuffer *outputBuffer = [[AVAudioPCMBuffer alloc] initWithPCMFormat:converter.outputFormat frameCapacity:BUFFER_SIZE_FRAMES];
 	AVAudioPCMBuffer *decodeBuffer = [[AVAudioPCMBuffer alloc] initWithPCMFormat:converter.inputFormat frameCapacity:BUFFER_SIZE_FRAMES];
 
+	__block NSError *decodeErr = nil;
+
 	for(;;) {
-		__block NSError *err = nil;
 		AVAudioConverterOutputStatus status = [converter convertToBuffer:outputBuffer error:error withInputFromBlock:^AVAudioBuffer * _Nullable(AVAudioPacketCount inNumberOfPackets, AVAudioConverterInputStatus * _Nonnull outStatus) {
-			BOOL result = [decoder decodeIntoBuffer:decodeBuffer frameLength:inNumberOfPackets error:&err];
-			if(!result)
-				os_log_error(OS_LOG_DEFAULT, "Error decoding audio: %{public}@", err);
-
-			if(result && decodeBuffer.frameLength == 0)
+			BOOL result = [decoder decodeIntoBuffer:decodeBuffer frameLength:inNumberOfPackets error:&decodeErr];
+			if(!result) {
+				*outStatus = AVAudioConverterInputStatus_NoDataNow;
+				return nil;
+			}
+			if(decodeBuffer.frameLength == 0) {
 				*outStatus = AVAudioConverterInputStatus_EndOfStream;
-			else
-				*outStatus = AVAudioConverterInputStatus_HaveData;
-
+				return nil;
+			}
+			*outStatus = AVAudioConverterInputStatus_HaveData;
 			return decodeBuffer;
 		}];
 
-		if(status == AVAudioConverterOutputStatus_Error) {
-#if TARGET_OS_TV
-			[[NSFileManager defaultManager] removeItemAtURL:targetURL error:nil];
-#else
-			[[NSFileManager defaultManager] trashItemAtURL:targetURL resultingItemURL:nil error:nil];
-#endif
-			if(error)
-				*error = err;
+		if (decodeErr) {
+			os_log_error(OS_LOG_DEFAULT, "Error decoding audio: %{public}@", decodeErr);
+			if(error) *error = decodeErr;
 			return NO;
 		}
-		else if(status == AVAudioConverterOutputStatus_EndOfStream)
+		if(status == AVAudioConverterOutputStatus_Error) {
+			os_log_error(OS_LOG_DEFAULT, "Error converting pcm audio: %{public}@", error ? *error : nil);
+			return NO;
+		}
+		if(status == AVAudioConverterOutputStatus_EndOfStream)
 			break;
 
-		if(![outputFile writeFromBuffer:outputBuffer error:&err]) {
-			os_log_error(OS_LOG_DEFAULT, "Error writing audio: %{public}@", err);
-#if TARGET_OS_TV
-			[[NSFileManager defaultManager] removeItemAtURL:targetURL error:nil];
-#else
-			[[NSFileManager defaultManager] trashItemAtURL:targetURL resultingItemURL:nil error:nil];
-#endif
-			if(error)
-				*error = err;
+		if(![outputFile writeFromBuffer:outputBuffer error:error]) {
+			os_log_error(OS_LOG_DEFAULT, "Error writing audio: %{public}@", error ? *error : nil);
 			return NO;
 		}
 	}

--- a/Sources/CSFBAudioEngine/Conversion/SFBAudioExporter.m
+++ b/Sources/CSFBAudioEngine/Conversion/SFBAudioExporter.m
@@ -49,6 +49,14 @@ NSErrorDomain const SFBAudioExporterErrorDomain = @"org.sbooth.AudioEngine.Audio
 	NSParameterAssert(decoder != nil);
 	NSParameterAssert(targetURL != nil);
 
+	void(^deleteOutputFile)() = ^{
+#if TARGET_OS_TV
+		[[NSFileManager defaultManager] removeItemAtURL:targetURL error:nil];
+#else
+		[[NSFileManager defaultManager] trashItemAtURL:targetURL resultingItemURL:nil error:nil];
+#endif
+	};
+
 	if(!decoder.isOpen && ![decoder openReturningError:error])
 		return NO;
 
@@ -73,37 +81,50 @@ NSErrorDomain const SFBAudioExporterErrorDomain = @"org.sbooth.AudioEngine.Audio
 	AVAudioPCMBuffer *outputBuffer = [[AVAudioPCMBuffer alloc] initWithPCMFormat:converter.outputFormat frameCapacity:BUFFER_SIZE_FRAMES];
 	AVAudioPCMBuffer *decodeBuffer = [[AVAudioPCMBuffer alloc] initWithPCMFormat:converter.inputFormat frameCapacity:BUFFER_SIZE_FRAMES];
 
-	__block NSError *decodeErr = nil;
+	__block BOOL decodeResult;
+	__block NSError *decodeError = nil;
+	NSError *convertError = nil;
+	NSError *writeError = nil;
 
 	for(;;) {
-		AVAudioConverterOutputStatus status = [converter convertToBuffer:outputBuffer error:error withInputFromBlock:^AVAudioBuffer * _Nullable(AVAudioPacketCount inNumberOfPackets, AVAudioConverterInputStatus * _Nonnull outStatus) {
-			BOOL result = [decoder decodeIntoBuffer:decodeBuffer frameLength:inNumberOfPackets error:&decodeErr];
-			if(!result) {
+		AVAudioConverterOutputStatus status = [converter convertToBuffer:outputBuffer error:error withInputFromBlock:^AVAudioBuffer *(AVAudioPacketCount inNumberOfPackets, AVAudioConverterInputStatus *outStatus) {
+			decodeResult = [decoder decodeIntoBuffer:decodeBuffer frameLength:inNumberOfPackets error:&decodeError];
+			if(!decodeResult) {
 				*outStatus = AVAudioConverterInputStatus_NoDataNow;
 				return nil;
 			}
+
 			if(decodeBuffer.frameLength == 0) {
 				*outStatus = AVAudioConverterInputStatus_EndOfStream;
 				return nil;
 			}
+
 			*outStatus = AVAudioConverterInputStatus_HaveData;
 			return decodeBuffer;
 		}];
 
-		if (decodeErr) {
-			os_log_error(OS_LOG_DEFAULT, "Error decoding audio: %{public}@", decodeErr);
-			if(error) *error = decodeErr;
+		if(!decodeResult) {
+			os_log_error(OS_LOG_DEFAULT, "Error decoding audio: %{public}@", decodeError);
+			if(error)
+				*error = decodeError;
+			deleteOutputFile();
 			return NO;
 		}
 		if(status == AVAudioConverterOutputStatus_Error) {
-			os_log_error(OS_LOG_DEFAULT, "Error converting pcm audio: %{public}@", error ? *error : nil);
+			os_log_error(OS_LOG_DEFAULT, "Error converting PCM audio: %{public}@", convertError);
+			if(error)
+				*error = convertError;
+			deleteOutputFile();
 			return NO;
 		}
-		if(status == AVAudioConverterOutputStatus_EndOfStream)
+		else if(status == AVAudioConverterOutputStatus_EndOfStream)
 			break;
 
-		if(![outputFile writeFromBuffer:outputBuffer error:error]) {
-			os_log_error(OS_LOG_DEFAULT, "Error writing audio: %{public}@", error ? *error : nil);
+		if(![outputFile writeFromBuffer:outputBuffer error:&writeError]) {
+			os_log_error(OS_LOG_DEFAULT, "Error writing audio: %{public}@", writeError);
+			if(error)
+				*error = writeError;
+			deleteOutputFile();
 			return NO;
 		}
 	}

--- a/Sources/CSFBAudioEngine/Conversion/SFBAudioExporter.m
+++ b/Sources/CSFBAudioEngine/Conversion/SFBAudioExporter.m
@@ -87,7 +87,7 @@ NSErrorDomain const SFBAudioExporterErrorDomain = @"org.sbooth.AudioEngine.Audio
 	NSError *writeError = nil;
 
 	for(;;) {
-		AVAudioConverterOutputStatus status = [converter convertToBuffer:outputBuffer error:error withInputFromBlock:^AVAudioBuffer *(AVAudioPacketCount inNumberOfPackets, AVAudioConverterInputStatus *outStatus) {
+		AVAudioConverterOutputStatus status = [converter convertToBuffer:outputBuffer error:&convertError withInputFromBlock:^AVAudioBuffer *(AVAudioPacketCount inNumberOfPackets, AVAudioConverterInputStatus *outStatus) {
 			decodeResult = [decoder decodeIntoBuffer:decodeBuffer frameLength:inNumberOfPackets error:&decodeError];
 			if(!decodeResult) {
 				*outStatus = AVAudioConverterInputStatus_NoDataNow;

--- a/Sources/CSFBAudioEngine/Conversion/SFBAudioExporter.m
+++ b/Sources/CSFBAudioEngine/Conversion/SFBAudioExporter.m
@@ -49,7 +49,7 @@ NSErrorDomain const SFBAudioExporterErrorDomain = @"org.sbooth.AudioEngine.Audio
 	NSParameterAssert(decoder != nil);
 	NSParameterAssert(targetURL != nil);
 
-	void(^deleteOutputFile)() = ^{
+	void(^deleteOutputFile)(void) = ^{
 #if TARGET_OS_TV
 		[[NSFileManager defaultManager] removeItemAtURL:targetURL error:nil];
 #else


### PR DESCRIPTION
Decoding error were not handled properly. If one occurred while the buffer was partially filled, the error was ignored.

One way to trigger a partial decoding error is to use the CoreAudioEncoder with the same input and output file.

This also fixes the conversion loop in SFBFileExporter. The file removal code was removed for now as it didn't handle all possible cases.