### PR TITLE
Use `Reset()`

### DIFF
--- a/Sources/CSFBAudioEngine/Player/SFBAudioPlayerNode.mm
+++ b/Sources/CSFBAudioEngine/Player/SFBAudioPlayerNode.mm
@@ -818,11 +818,8 @@ public:
 			return false;
 		}
 
-		if(reset) {
-			ClearQueue();
-			if(auto decoderState = GetActiveDecoderStateWithSmallestSequenceNumber(); decoderState)
-				decoderState->mFlags.fetch_or(DecoderState::eFlagCancelDecoding);
-		}
+		if(reset)
+			Reset();
 
 		os_log_info(_audioPlayerNodeLog, "Enqueuing %{public}@", decoder);
 


### PR DESCRIPTION
The previous implementation was incomplete and didn't signal the decoding semaphore.