### PR TITLE
Ensure the end of audio event is only submitted once

### DIFF
--- a/Sources/CSFBAudioEngine/Player/SFBAudioPlayer.mm
+++ b/Sources/CSFBAudioEngine/Player/SFBAudioPlayer.mm
@@ -1130,6 +1130,7 @@ NSString * _Nullable AudioDeviceName(AUAudioUnit * _Nonnull audioUnit) noexcept
 			return;
 		}
 
+		// If there is an imminent or pending decoder swallow the event
 		if(const auto flags = self->_flags.load(); (flags & eAudioPlayerFlagRenderingImminent) || (flags & eAudioPlayerFlagHavePendingDecoder))
 			return;
 


### PR DESCRIPTION
~Fixes 488~

~The change to submit the end of audio event only once still seems correct.~

The changes in #497 make this PR unnecessary.