### PR TITLE
SFBAudioPlayerNode: fix infinite loop on destruction

### DIFF
--- a/Sources/CSFBAudioEngine/Player/SFBAudioPlayerNode.mm
+++ b/Sources/CSFBAudioEngine/Player/SFBAudioPlayerNode.mm
@@ -542,8 +542,8 @@ public:
 
 	~AudioPlayerNode()
 	{
-		mFlags.fetch_and(~eFlagIsPlaying);
-		CancelCurrentDecoder();
+		// Cancel all actives and pending decoders.
+		Stop();
 
 		// Cancel any further event processing initiated by the render block
 		dispatch_source_cancel(mEventProcessingSource);


### PR DESCRIPTION
All actives and pending decoders must be cleared to prevent waiting forever for the mDecodingGroup.