### PR TITLE
Call `Stop` in destructor

### DIFF
--- a/Sources/CSFBAudioEngine/Player/SFBAudioPlayerNode.mm
+++ b/Sources/CSFBAudioEngine/Player/SFBAudioPlayerNode.mm
@@ -542,8 +542,7 @@ public:
 
 	~AudioPlayerNode()
 	{
-		mFlags.fetch_and(~eFlagIsPlaying);
-		CancelCurrentDecoder();
+		Stop();
 
 		// Cancel any further event processing initiated by the render block
 		dispatch_source_cancel(mEventProcessingSource);


### PR DESCRIPTION
This ensures all pending decoders are cleared to prevent waiting forever on `mDecodingGroup`