### PR TITLE
Ensure post-rendering bookkeeping is always performed

### DIFF
--- a/Sources/CSFBAudioEngine/Player/AudioPlayerNode.mm
+++ b/Sources/CSFBAudioEngine/Player/AudioPlayerNode.mm
@@ -977,7 +977,7 @@ OSStatus SFB::AudioPlayerNode::Render(BOOL& isSilence, const AudioTimeStamp& tim
 	}
 
 	// Determine how many audio frames are available to read from the ring buffer
-	const auto framesAvailableToRead = static_cast<AVAudioFrameCount>(mAudioRingBuffer.FramesAvailableToRead());
+	const AVAudioFrameCount framesAvailableToRead = mAudioRingBuffer.FramesAvailableToRead();
 
 	// The number of frames read from the ring buffer
 	AVAudioFrameCount framesRead = 0;
@@ -994,7 +994,7 @@ OSStatus SFB::AudioPlayerNode::Render(BOOL& isSilence, const AudioTimeStamp& tim
 	// Otherwise read as many frames as available from the ring buffer
 	else {
 		const auto framesToRead = std::min(framesAvailableToRead, frameCount);
-		framesRead = static_cast<AVAudioFrameCount>(mAudioRingBuffer.Read(outputData, framesToRead));
+		framesRead = mAudioRingBuffer.Read(outputData, framesToRead);
 		if(framesRead != framesToRead)
 			os_log_fault(sLog, "SFB::AudioRingBuffer::Read failed: Requested %u frames, got %u", framesToRead, framesRead);
 

--- a/Sources/CSFBAudioEngine/Player/AudioPlayerNode.mm
+++ b/Sources/CSFBAudioEngine/Player/AudioPlayerNode.mm
@@ -980,7 +980,7 @@ OSStatus SFB::AudioPlayerNode::Render(BOOL& isSilence, const AudioTimeStamp& tim
 	const auto framesAvailableToRead = static_cast<AVAudioFrameCount>(mAudioRingBuffer.FramesAvailableToRead());
 
 	// The number of frames read from the ring buffer
-	AVAudioFramePosition framesRead = 0;
+	AVAudioFrameCount framesRead = 0;
 
 	// Output silence if the ring buffer is empty
 	if(framesAvailableToRead == 0) {


### PR DESCRIPTION
This is primarily a fix for a bug in `ExtAudioFile` where `ExtAudioFileRead` returns zero frames despite not reaching EOF, (documentation to the contrary notwithstanding). 

It also addresses a situation where decoding is complete but zero frames are available in the ring buffer, so the rendering complete notification would never be sent.