### PR TITLE
Suppress warning about conformance of imported type

### DIFF
--- a/Sources/SFBAudioEngine/SFBAudioPlayer.swift
+++ b/Sources/SFBAudioEngine/SFBAudioPlayer.swift
@@ -59,7 +59,7 @@ extension AudioPlayer {
 	}
 }
 
-extension AudioPlayer.PlaybackState: @retroactive CustomDebugStringConvertible {
+extension AudioPlayer.PlaybackState: /*@retroactive*/ Swift.CustomDebugStringConvertible {
 	// A textual representation of this instance, suitable for debugging.
 	public var debugDescription: String {
 		switch self {


### PR DESCRIPTION
While still supporting pre-Swift 6 language modes