### PR TITLE
Add permissions to workflow

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build:
 
+    permissions:
+      contents: read
     runs-on: macos-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/sbooth/SFBAudioEngine/security/code-scanning/1](https://github.com/sbooth/SFBAudioEngine/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly restrict the GITHUB_TOKEN permissions. The most appropriate and minimal change is to add `permissions: contents: read` at the job level (under `build:`), as this job only requires code checkout and build/test commands and does not need write access to any resources. This ensures GITHUB_TOKEN has only read-level access to repository contents for the duration of the job, guarding against accidental privilege escalation. Place the `permissions` block directly under the `build:` job definition (before or after `runs-on`, typically before, for clarity).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
