### PR TITLE
Use `uint8_t` for pointer arithmetic with known types

### DIFF
--- a/Sources/CSFBAudioEngine/Decoders/SFBDSDIFFDecoder.mm
+++ b/Sources/CSFBAudioEngine/Decoders/SFBDSDIFFDecoder.mm
@@ -871,7 +871,7 @@ static NSError * CreateInvalidDSDIFFFileError(NSURL * url)
 		// Read interleaved input, grouped as 8 one bit samples per frame (a single channel byte) into
 		// a clustered frame (one channel byte per channel)
 
-		auto buf = static_cast<uint8_t *>(reinterpret_cast<void *>(reinterpret_cast<uintptr_t>(buffer.data) + buffer.byteLength));
+		auto buf = static_cast<uint8_t *>(buffer.data) + buffer.byteLength;
 		NSInteger bytesToRead = std::min(packetsToRead * packetSize, buffer.byteCapacity - buffer.byteLength);
 
 		NSInteger bytesRead;

--- a/Sources/CSFBAudioEngine/Decoders/SFBDSDPCMDecoder.mm
+++ b/Sources/CSFBAudioEngine/Decoders/SFBDSDPCMDecoder.mm
@@ -485,7 +485,7 @@ private:
 		AVAudioChannelCount channelCount = buffer.format.channelCount;
 		bool isBigEndian = _buffer.format.streamDescription->mFormatFlags & kAudioFormatFlagIsBigEndian;
 		for(AVAudioChannelCount channel = 0; channel < channelCount; ++channel) {
-			const auto input = static_cast<const uint8_t *>(reinterpret_cast<const void *>(reinterpret_cast<uintptr_t>(_buffer.data) + channel));
+			const auto input = static_cast<const uint8_t *>(_buffer.data) + channel;
 			float *output = floatChannelData[channel];
 			_context[channel].Translate(framesDecoded, input, channelCount, !isBigEndian, output, 1);
 			// Boost signal by 6 dBFS

--- a/Sources/CSFBAudioEngine/Decoders/SFBDSFDecoder.m
+++ b/Sources/CSFBAudioEngine/Decoders/SFBDSFDecoder.m
@@ -347,7 +347,7 @@ static void MatrixTransposeNaive(const uint8_t * restrict A, uint8_t * restrict 
 
 		// Copy data from the internal buffer to output
 		uint32_t copySize = packetsToCopy * packetSize;
-		memcpy((void *)((uintptr_t)buffer.data + (packetsToSkip * packetSize)), _buffer.data, copySize);
+		memcpy((uint8_t *)buffer.data + (packetsToSkip * packetSize), _buffer.data, copySize);
 		buffer.packetCount += packetsToCopy;
 		buffer.byteLength += copySize;
 
@@ -404,7 +404,7 @@ static void MatrixTransposeNaive(const uint8_t * restrict A, uint8_t * restrict 
 
 	// Move data
 	uint32_t packetSize = kSFBBytesPerDSDPacketPerChannel * _processingFormat.channelCount;
-	const void *src = (const void *)((uintptr_t)_buffer.data + (packetsToSkip * packetSize));
+	const uint8_t *src = (uint8_t *)_buffer.data + (packetsToSkip * packetSize);
 	memmove(_buffer.data, src, packetsToMove * packetSize);
 
 	_buffer.packetCount = packetsToMove;

--- a/Sources/CSFBAudioEngine/Decoders/SFBDoPDecoder.m
+++ b/Sources/CSFBAudioEngine/Decoders/SFBDoPDecoder.m
@@ -230,8 +230,8 @@ static BOOL IsSupportedDoPSampleRate(Float64 sampleRate)
 		uint8_t marker = _marker;
 		AVAudioChannelCount channelCount = _processingFormat.channelCount;
 		for(AVAudioChannelCount channel = 0; channel < channelCount; ++channel) {
-			const uint8_t *input = (const void *)((uintptr_t)_buffer.data + channel);
-			uint8_t *output = (void *)((uintptr_t)buffer.audioBufferList->mBuffers[channel].mData + buffer.audioBufferList->mBuffers[channel].mDataByteSize);
+			const uint8_t *input = (const uint8_t *)_buffer.data + channel;
+			uint8_t *output = (uint8_t *)buffer.audioBufferList->mBuffers[channel].mData + buffer.audioBufferList->mBuffers[channel].mDataByteSize;
 
 			// The DoP marker should match across channels
 			marker = _marker;

--- a/Sources/CSFBAudioEngine/Encoders/SFBFLACEncoder.mm
+++ b/Sources/CSFBAudioEngine/Encoders/SFBFLACEncoder.mm
@@ -392,7 +392,7 @@ void metadata_callback(const FLAC__StreamEncoder *encoder, const FLAC__StreamMet
 
 			const auto frameOffset = frameLength - framesRemaining;
 			const auto byteOffset = frameOffset * format->mBytesPerFrame;
-			const auto src = static_cast<int32_t *>(reinterpret_cast<void *>(reinterpret_cast<uintptr_t>(buffer.audioBufferList->mBuffers[0].mData) + byteOffset));
+			const auto src = static_cast<int32_t *>(buffer.audioBufferList->mBuffers[0].mData) + byteOffset;
 
 			// Shift from high alignment, sign extending in the process
 			for(AVAudioFrameCount i = 0; i < frameCount * stride; ++i)

--- a/Sources/CSFBAudioEngine/Output/SFBBufferOutputSource.m
+++ b/Sources/CSFBAudioEngine/Output/SFBBufferOutputSource.m
@@ -61,7 +61,7 @@
 	}
 
 	size_t bytesToCopy = MIN(bytesAvailable, (size_t)length);
-	memcpy(buffer, (const void *)((uintptr_t)_buffer + _pos), bytesToCopy);
+	memcpy(buffer, (const uint8_t *)_buffer + _pos, bytesToCopy);
 	_pos += bytesToCopy;
 	*bytesRead = (NSInteger)bytesToCopy;
 
@@ -82,7 +82,7 @@
 	}
 
 	size_t bytesToCopy = MIN(remainingCapacity, (size_t)length);
-	memcpy((void *)((uintptr_t)_buffer + _pos), buffer, bytesToCopy);
+	memcpy((uint8_t *)_buffer + _pos, buffer, bytesToCopy);
 	_pos += bytesToCopy;
 	*bytesWritten = (NSInteger)bytesToCopy;
 


### PR DESCRIPTION
This removes the use of `uintptr_t` since no address manipulation is being performed.