### PR TITLE
Fix a race condition leading to erroneous now playing changes

### DIFF
--- a/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
+++ b/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
@@ -1068,9 +1068,11 @@ void SFB::AudioPlayer::ProcessDecoders(std::stop_token stoken) noexcept
 		// Dequeue the next decoder if there are no decoders that haven't completed decoding
 		if(!decoderState) {
 			{
+				// Lock both mutexes to ensure a decoder doesn't momentarily "disappear"
+				// when transitioning from queued to active
 				std::scoped_lock lock{queuedDecodersLock_, activeDecodersLock_};
 
-				/// Remove and returns the first decoder from the decoder queue
+				// Remove the first decoder from the decoder queue
 				Decoder decoder = nil;
 				if(!queuedDecoders_.empty()) {
 					decoder = queuedDecoders_.front();


### PR DESCRIPTION
## Pull request overview

This PR fixes a race condition that could cause erroneous "now playing" changes by improving synchronization when decoders transition between queued and active states.

Key changes:
- Reordered operations in `EnqueueDecoder` to prevent a timing window where the decoder queue appears empty during immediate playback
- Added dual-mutex locking during decoder queue-to-active transitions to ensure atomic visibility
- Consolidated decoder existence checks to verify both queued and active decoders under proper locking