### PR TITLE
Ensure playback state transitions are sequenced properly

### DIFF
--- a/Sources/CSFBAudioEngine/Player/AudioPlayer.h
+++ b/Sources/CSFBAudioEngine/Player/AudioPlayer.h
@@ -97,6 +97,11 @@ private:
 	std::atomic_uint 						flags_ 				{0};
 	static_assert(std::atomic_uint::is_always_lock_free, "Lock-free std::atomic_uint required");
 
+#if TARGET_OS_IPHONE
+	/// Playback state before audio session interruption
+	unsigned int 							preInterruptState_ 	{0};
+#endif /* TARGET_OS_IPHONE */
+
 public:
 	AudioPlayer();
 


### PR DESCRIPTION
## Pull request overview

This PR addresses a critical race condition in audio playback state management by ensuring that all state transitions are properly sequenced under lock protection. The changes prevent scenarios where calling `Play()` immediately followed by `Stop()` could leave the player in an inconsistent state.

**Changes:**
- Modified `Play()`, `Pause()`, `Resume()`, and `Stop()` methods to hold `engineLock_` during the entire state transition, including flag updates
- Updated delegate notification logic to only fire when actual state changes occur, preventing redundant notifications
- Adjusted interruption handler to properly scope the engine lock