### PR TITLE
Update `engineLock_` documentation comment

### DIFF
--- a/Sources/CSFBAudioEngine/Player/AudioPlayer.h
+++ b/Sources/CSFBAudioEngine/Player/AudioPlayer.h
@@ -82,7 +82,7 @@ private:
 	AVAudioEngine 							*engine_ 			{nil};
 	/// Source node driving the audio processing graph
 	AVAudioSourceNode						*sourceNode_ 		{nil};
-	/// Lock protecting processing graph configuration changes
+	/// Lock protecting playback state and processing graph configuration changes
 	mutable CXXUnfairLock::UnfairLock 		engineLock_;
 
 	/// Decoder currently rendering audio


### PR DESCRIPTION
## Pull request overview

This pull request updates the documentation comment for the `engineLock_` member variable to more accurately reflect its responsibilities. The lock protects both playback state flags and processing graph configuration changes, not just the processing graph configuration alone.

**Changes:**
- Updated the documentation comment for `engineLock_` to include "playback state" in addition to "processing graph configuration changes"