### PR TITLE
Don't access `audioRingBuffer_` in event processing thread

### DIFF
--- a/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
+++ b/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
@@ -1649,7 +1649,7 @@ bool SFB::AudioPlayer::ProcessFramesRenderedEvent() noexcept
 				(*iter)->flags_.fetch_or(static_cast<unsigned int>(DecoderState::Flags::renderingStarted), std::memory_order_acq_rel);
 
 				const auto frameOffset = framesRendered - framesRemainingToDistribute;
-				const double deltaSeconds = frameOffset / audioRingBuffer_.Format().mSampleRate;
+				const double deltaSeconds = frameOffset / (*iter)->sampleRate_;
 				uint64_t eventTime = hostTime + SFB::ConvertSecondsToHostTime(deltaSeconds * rateScalar);
 
 				try {
@@ -1667,7 +1667,7 @@ bool SFB::AudioPlayer::ProcessFramesRenderedEvent() noexcept
 			// Rendering is complete
 			if(constexpr auto mask = static_cast<unsigned int>(DecoderState::Flags::isCanceled) | static_cast<unsigned int>(DecoderState::Flags::decodingComplete); (flags & mask) == static_cast<unsigned int>(DecoderState::Flags::decodingComplete) && framesFromThisDecoder == decoderFramesRemaining) {
 				const auto frameOffset = framesRendered - framesRemainingToDistribute;
-				const double deltaSeconds = frameOffset / audioRingBuffer_.Format().mSampleRate;
+				const double deltaSeconds = frameOffset / (*iter)->sampleRate_;
 				uint64_t eventTime = hostTime + SFB::ConvertSecondsToHostTime(deltaSeconds * rateScalar);
 
 				try {


### PR DESCRIPTION
## Pull request overview

This pull request improves thread safety by eliminating accesses to `audioRingBuffer_` from the event processing thread during frame rendering event processing.

**Changes:**
- Replaced `audioRingBuffer_.Format().mSampleRate` with `(*iter)->sampleRate_` for calculating time deltas
- Changed two occurrences in `ProcessFramesRenderedEvent()` function (lines 1652 and 1670)