### PR TITLE
Remove code after `return`

### DIFF
--- a/Sources/CSFBAudioEngine/Input/SFBInputSource.m
+++ b/Sources/CSFBAudioEngine/Input/SFBInputSource.m
@@ -62,10 +62,9 @@ static void SFBCreateInputSourceLog(void)
 
 	if(flags & SFBInputSourceFlagsMemoryMapFiles)
 		return [[SFBMemoryMappedFileInputSource alloc] initWithURL:url error:error];
-	else if(flags & SFBInputSourceFlagsLoadFilesInMemory)
+	if(flags & SFBInputSourceFlagsLoadFilesInMemory)
 		return [[SFBFileContentsInputSource alloc] initWithContentsOfURL:url error:error];
-	else
-		return [[SFBFileInputSource alloc] initWithURL:url];
+	return [[SFBFileInputSource alloc] initWithURL:url];
 }
 
 + (instancetype)inputSourceWithData:(NSData *)data


### PR DESCRIPTION
## Pull request overview

This PR removes unreachable code that appeared after an unconditional `return` statement in the `inputSourceForURL:flags:error:` method.

**Changes:**
- Removed 4 lines of unreachable error handling code that could never be executed