### PR TITLE
Add `audioPlayer:audioSessionInterruption:` delegate method

### DIFF
--- a/Sources/CSFBAudioEngine/include/SFBAudioEngine/SFBAudioPlayer.h
+++ b/Sources/CSFBAudioEngine/include/SFBAudioEngine/SFBAudioPlayer.h
@@ -385,7 +385,7 @@ NS_SWIFT_NAME(AudioPlayer.Delegate) @protocol SFBAudioPlayerDelegate <NSObject>
 /// Called to notify the delegate of an `AVAudioSession` interruption begin or end
 ///
 /// If the interruption began, this method is called after the playback state is saved and the player is stopped.
-/// If the interruption ended, this method is called before attempting to activate the audio session and optionally resume playback.
+/// If the interruption ended, this method is called before optionally attempting to activate the audio session and resume playback.
 /// - parameter audioPlayer: The `SFBAudioPlayer` object
 /// - parameter userInfo: The `userInfo` object from the notification
 - (void)audioPlayer:(SFBAudioPlayer *)audioPlayer audioSessionInterruption:(nullable NSDictionary *)userInfo;


### PR DESCRIPTION
## Pull request overview

This pull request adds a new delegate method `audioPlayer:audioSessionInterruption:` to notify delegates when an `AVAudioSession` interruption occurs on iOS platforms. The implementation also refines error handling during session interruption recovery by using `break` instead of early returns, allowing the new delegate method to be called in all interruption scenarios.

**Changes:**
- Added new delegate method `audioPlayer:audioSessionInterruption:` to the `SFBAudioPlayerDelegate` protocol
- Moved `encounteredError:` delegate method declaration earlier in the protocol to improve logical grouping
- Updated interruption handling to use `break` instead of `return` to ensure delegate notification
- Updated documentation comments to reflect the new delegate callback