### PR TITLE
Rename `handleAudioSessionInterruption`

### DIFF
--- a/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
+++ b/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
@@ -1957,7 +1957,7 @@ void sfb::AudioPlayer::handleAudioEngineConfigurationChange(AVAudioEngine *engin
 }
 
 #if TARGET_OS_IPHONE
-void sfb::AudioPlayer::HandleAudioSessionInterruption(NSDictionary *userInfo) noexcept
+void sfb::AudioPlayer::handleAudioSessionInterruption(NSDictionary *userInfo) noexcept
 {
 	const auto interruptionType = [[userInfo objectForKey:AVAudioSessionInterruptionTypeKey] unsignedIntegerValue];
 	switch(interruptionType) {


### PR DESCRIPTION
## Pull request overview

This PR renames the `HandleAudioSessionInterruption` method to follow the camelCase naming convention used throughout the codebase, aligning it with similar methods like `handleAudioEngineConfigurationChange`.

**Changes:**
- Renamed method implementation from `HandleAudioSessionInterruption` to `handleAudioSessionInterruption` in AudioPlayer.mm