### PR TITLE
Update imports

### DIFF
--- a/Extra/SFBFFmpegDecoder.m
+++ b/Extra/SFBFFmpegDecoder.m
@@ -4,7 +4,7 @@
 // MIT license
 //
 
-@import os.log;
+#import <os/log.h>
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wconversion"

--- a/Extra/SFBModuleFile.m
+++ b/Extra/SFBModuleFile.m
@@ -4,9 +4,9 @@
 // MIT license
 //
 
-@import os.log;
+#import <os/log.h>
 
-@import dumb;
+#import <dumb/dumb.h>
 
 #import "SFBModuleFile.h"
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sbooth/AVFAudioExtensions",
       "state" : {
-        "revision" : "16b850dd542bbe8001b02596595309c8171f002d",
-        "version" : "0.4.2"
+        "revision" : "541d8617956cc46af45c2c5ae3f7c23439a2f666",
+        "version" : "0.5.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
             ]),
     ],
     dependencies: [
-        .package(url: "https://github.com/sbooth/AVFAudioExtensions", .upToNextMinor(from: "0.4.2")),
+        .package(url: "https://github.com/sbooth/AVFAudioExtensions", .upToNextMinor(from: "0.5.0")),
         .package(url: "https://github.com/sbooth/CXXAudioToolbox", .upToNextMinor(from: "0.2.0")),
         .package(url: "https://github.com/sbooth/CXXCoreAudio", .upToNextMinor(from: "0.5.1")),
         .package(url: "https://github.com/sbooth/CXXRingBuffer", .upToNextMinor(from: "0.5.2")),

--- a/Sources/CSFBAudioEngine/Analysis/SFBReplayGainAnalyzer.m
+++ b/Sources/CSFBAudioEngine/Analysis/SFBReplayGainAnalyzer.m
@@ -4,9 +4,9 @@
 // MIT license
 //
 
-@import os.log;
+#import <os/log.h>
 
-@import Accelerate;
+#import <Accelerate/Accelerate.h>
 
 #import "SFBReplayGainAnalyzer.h"
 

--- a/Sources/CSFBAudioEngine/Conversion/SFBAudioConverter.m
+++ b/Sources/CSFBAudioEngine/Conversion/SFBAudioConverter.m
@@ -4,7 +4,7 @@
 // MIT license
 //
 
-@import os.log;
+#import <os/log.h>
 
 #import "SFBAudioConverter.h"
 

--- a/Sources/CSFBAudioEngine/Conversion/SFBAudioExporter.m
+++ b/Sources/CSFBAudioEngine/Conversion/SFBAudioExporter.m
@@ -4,9 +4,9 @@
 // MIT license
 //
 
-@import os.log;
+#import <os/log.h>
 
-@import AVFAudioExtensions;
+#import <AVFAudioExtensions/AVFAudioExtensions.h>
 
 #import "SFBAudioExporter.h"
 

--- a/Sources/CSFBAudioEngine/Decoders/SFBAudioDecoder.m
+++ b/Sources/CSFBAudioEngine/Decoders/SFBAudioDecoder.m
@@ -4,7 +4,7 @@
 // MIT license
 //
 
-@import os.log;
+#import <os/log.h>
 
 #import "SFBAudioDecoder.h"
 #import "SFBAudioDecoder+Internal.h"

--- a/Sources/CSFBAudioEngine/Decoders/SFBAudioRegionDecoder.m
+++ b/Sources/CSFBAudioEngine/Decoders/SFBAudioRegionDecoder.m
@@ -4,10 +4,10 @@
 // MIT license
 //
 
-@import os.log;
-@import stdlib_h;
+#import <os/log.h>
+#import <stdlib.h>
 
-@import AVFAudioExtensions;
+#import <AVFAudioExtensions/AVFAudioExtensions.h>
 
 #import "SFBAudioRegionDecoder.h"
 

--- a/Sources/CSFBAudioEngine/Decoders/SFBDSDDecoder.m
+++ b/Sources/CSFBAudioEngine/Decoders/SFBDSDDecoder.m
@@ -4,7 +4,7 @@
 // MIT license
 //
 
-@import os.log;
+#import <os/log.h>
 
 #import "SFBDSDDecoder.h"
 #import "SFBDSDDecoder+Internal.h"

--- a/Sources/CSFBAudioEngine/Decoders/SFBDSDIFFDecoder.mm
+++ b/Sources/CSFBAudioEngine/Decoders/SFBDSDIFFDecoder.mm
@@ -12,7 +12,7 @@
 
 #import <os/log.h>
 
-#import <AVAudioChannelLayout+SFBChannelLabels.h>
+#import <AVFAudioExtensions/AVFAudioExtensions.h>
 
 #import "SFBDSDIFFDecoder.h"
 

--- a/Sources/CSFBAudioEngine/Decoders/SFBDSDPCMDecoder.mm
+++ b/Sources/CSFBAudioEngine/Decoders/SFBDSDPCMDecoder.mm
@@ -12,7 +12,7 @@
 
 #import <Accelerate/Accelerate.h>
 
-#import <AVAudioPCMBuffer+SFBBufferUtilities.h>
+#import <AVFAudioExtensions/AVFAudioExtensions.h>
 
 #import "SFBDSDPCMDecoder.h"
 

--- a/Sources/CSFBAudioEngine/Decoders/SFBDSFDecoder.m
+++ b/Sources/CSFBAudioEngine/Decoders/SFBDSFDecoder.m
@@ -6,7 +6,7 @@
 
 #import <stdint.h>
 
-@import os.log;
+#import <os/log.h>
 
 #import "SFBDSFDecoder.h"
 

--- a/Sources/CSFBAudioEngine/Decoders/SFBDoPDecoder.m
+++ b/Sources/CSFBAudioEngine/Decoders/SFBDoPDecoder.m
@@ -6,9 +6,9 @@
 
 #import <stdint.h>
 
-@import os.log;
+#import <os/log.h>
 
-@import AVFAudioExtensions;
+#import <AVFAudioExtensions/AVFAudioExtensions.h>
 
 #import "SFBDoPDecoder.h"
 

--- a/Sources/CSFBAudioEngine/Decoders/SFBFLACDecoder.mm
+++ b/Sources/CSFBAudioEngine/Decoders/SFBFLACDecoder.mm
@@ -13,7 +13,7 @@
 #import <FLAC/metadata.h>
 #import <FLAC/stream_decoder.h>
 
-#import <AVAudioPCMBuffer+SFBBufferUtilities.h>
+#import <AVFAudioExtensions/AVFAudioExtensions.h>
 
 #import "SFBFLACDecoder.h"
 

--- a/Sources/CSFBAudioEngine/Decoders/SFBLibsndfileDecoder.m
+++ b/Sources/CSFBAudioEngine/Decoders/SFBLibsndfileDecoder.m
@@ -4,10 +4,10 @@
 // MIT license
 //
 
-@import os.log;
+#import <os/log.h>
 
-@import sndfile;
-@import AVFAudioExtensions;
+#import <sndfile/sndfile.h>
+#import <AVFAudioExtensions/AVFAudioExtensions.h>
 
 #import "SFBLibsndfileDecoder.h"
 

--- a/Sources/CSFBAudioEngine/Decoders/SFBMPEGDecoder.m
+++ b/Sources/CSFBAudioEngine/Decoders/SFBMPEGDecoder.m
@@ -4,11 +4,10 @@
 // MIT license
 //
 
-@import os.log;
+#import <os/log.h>
 
-// TODO: Figure out a way to selectively disable diagnostic warnings for module imports
-@import mpg123;
-@import AVFAudioExtensions;
+#import <mpg123/mpg123.h>
+#import <AVFAudioExtensions/AVFAudioExtensions.h>
 
 #import "SFBMPEGDecoder.h"
 

--- a/Sources/CSFBAudioEngine/Decoders/SFBModuleDecoder.m
+++ b/Sources/CSFBAudioEngine/Decoders/SFBModuleDecoder.m
@@ -4,9 +4,9 @@
 // MIT license
 //
 
-@import os.log;
+#import <os/log.h>
 
-@import dumb;
+#import <dumb/dumb.h>
 
 #import "SFBModuleDecoder.h"
 

--- a/Sources/CSFBAudioEngine/Decoders/SFBMusepackDecoder.m
+++ b/Sources/CSFBAudioEngine/Decoders/SFBMusepackDecoder.m
@@ -4,13 +4,12 @@
 // MIT license
 //
 
-@import os.log;
+#import <os/log.h>
 
-@import Accelerate;
+#import <Accelerate/Accelerate.h>
 
-// TODO: Figure out a way to selectively disable diagnostic warnings for module imports
-@import mpc.dec;
-@import AVFAudioExtensions;
+#import <mpc/mpcdec.h>
+#import <AVFAudioExtensions/AVFAudioExtensions.h>
 
 #import "SFBMusepackDecoder.h"
 

--- a/Sources/CSFBAudioEngine/Decoders/SFBOggOpusDecoder.m
+++ b/Sources/CSFBAudioEngine/Decoders/SFBOggOpusDecoder.m
@@ -4,10 +4,10 @@
 // MIT license
 //
 
-@import os.log;
+#import <os/log.h>
 
-@import opus.file;
-@import AVFAudioExtensions;
+#import <opus/opusfile.h>
+#import <AVFAudioExtensions/AVFAudioExtensions.h>
 
 #import "SFBOggOpusDecoder.h"
 

--- a/Sources/CSFBAudioEngine/Decoders/SFBOggSpeexDecoder.m
+++ b/Sources/CSFBAudioEngine/Decoders/SFBOggSpeexDecoder.m
@@ -4,13 +4,13 @@
 // MIT license
 //
 
-@import os.log;
+#import <os/log.h>
 
-@import Accelerate;
+#import <Accelerate/Accelerate.h>
 
-@import ogg;
-@import speex;
-@import AVFAudioExtensions;
+#import <ogg/ogg.h>
+#import <speex/speex.h>
+#import <AVFAudioExtensions/AVFAudioExtensions.h>
 
 #import "SFBOggSpeexDecoder.h"
 

--- a/Sources/CSFBAudioEngine/Decoders/SFBOggVorbisDecoder.m
+++ b/Sources/CSFBAudioEngine/Decoders/SFBOggVorbisDecoder.m
@@ -4,10 +4,10 @@
 // MIT license
 //
 
-@import os.log;
+#import <os/log.h>
 
-@import vorbis;
-@import AVFAudioExtensions;
+#import <vorbis/vorbisfile.h>
+#import <AVFAudioExtensions/AVFAudioExtensions.h>
 
 #import "SFBOggVorbisDecoder.h"
 

--- a/Sources/CSFBAudioEngine/Decoders/SFBShortenDecoder.mm
+++ b/Sources/CSFBAudioEngine/Decoders/SFBShortenDecoder.mm
@@ -14,7 +14,7 @@
 
 #import <os/log.h>
 
-#import <AVAudioPCMBuffer+SFBBufferUtilities.h>
+#import <AVFAudioExtensions/AVFAudioExtensions.h>
 
 #import "SFBShortenDecoder.h"
 

--- a/Sources/CSFBAudioEngine/Decoders/SFBWavPackDecoder.m
+++ b/Sources/CSFBAudioEngine/Decoders/SFBWavPackDecoder.m
@@ -4,12 +4,12 @@
 // MIT license
 //
 
-@import os.log;
+#import <os/log.h>
 
-@import AudioToolbox;
+#import <AudioToolbox/AudioToolbox.h>
 
-@import wavpack;
-@import AVFAudioExtensions;
+#import <wavpack/wavpack.h>
+#import <AVFAudioExtensions/AVFAudioExtensions.h>
 
 #import "SFBWavPackDecoder.h"
 

--- a/Sources/CSFBAudioEngine/Encoders/SFBAudioEncoder.m
+++ b/Sources/CSFBAudioEngine/Encoders/SFBAudioEncoder.m
@@ -4,7 +4,7 @@
 // MIT license
 //
 
-@import os.log;
+#import <os/log.h>
 
 #import "SFBAudioEncoder.h"
 #import "SFBAudioEncoder+Internal.h"

--- a/Sources/CSFBAudioEngine/Encoders/SFBLibsndfileEncoder.m
+++ b/Sources/CSFBAudioEngine/Encoders/SFBLibsndfileEncoder.m
@@ -4,12 +4,12 @@
 // MIT license
 //
 
-@import os.log;
+#import <os/log.h>
 
-@import AudioToolbox;
+#import <AudioToolbox/AudioToolbox.h>
 
-@import sndfile;
-@import AVFAudioExtensions;
+#import <sndfile/sndfile.h>
+#import <AVFAudioExtensions/AVFAudioExtensions.h>
 
 #import "SFBLibsndfileEncoder.h"
 

--- a/Sources/CSFBAudioEngine/Encoders/SFBMusepackEncoder.m
+++ b/Sources/CSFBAudioEngine/Encoders/SFBMusepackEncoder.m
@@ -4,11 +4,10 @@
 // MIT license
 //
 
-@import os.log;
+#import <os/log.h>
 
-// TODO: Figure out a way to selectively disable diagnostic warnings for module imports
-@import mpc.enc;
-@import AVFAudioExtensions;
+#import <mpc/libmpcenc.h>
+#import <AVFAudioExtensions/AVFAudioExtensions.h>
 
 #import "SFBMusepackEncoder.h"
 

--- a/Sources/CSFBAudioEngine/Encoders/SFBOggOpusEncoder.mm
+++ b/Sources/CSFBAudioEngine/Encoders/SFBOggOpusEncoder.mm
@@ -11,7 +11,7 @@
 
 #import <opus/opusenc.h>
 
-#import <AVAudioPCMBuffer+SFBBufferUtilities.h>
+#import <AVFAudioExtensions/AVFAudioExtensions.h>
 
 #import "SFBOggOpusEncoder.h"
 

--- a/Sources/CSFBAudioEngine/Encoders/SFBOggSpeexEncoder.m
+++ b/Sources/CSFBAudioEngine/Encoders/SFBOggSpeexEncoder.m
@@ -4,13 +4,13 @@
 // MIT license
 //
 
-@import os.log;
+#import <os/log.h>
 
-@import ogg;
-// TODO: Figure out a way to selectively disable diagnostic warnings for module imports
-@import speex;
+#import <ogg/ogg.h>
+#import <speex/speex.h>
+#import <speex/speexdsp_types.h>
 
-#import <AVAudioPCMBuffer+SFBBufferUtilities.h>
+#import <AVFAudioExtensions/AVFAudioExtensions.h>
 
 #import "SFBOggSpeexEncoder.h"
 

--- a/Sources/CSFBAudioEngine/Encoders/SFBOggVorbisEncoder.m
+++ b/Sources/CSFBAudioEngine/Encoders/SFBOggVorbisEncoder.m
@@ -4,11 +4,10 @@
 // MIT license
 //
 
-@import os.log;
+#import <os/log.h>
 
-// TODO: Figure out a way to selectively disable diagnostic warnings for module imports
-@import vorbis;
-@import AVFAudioExtensions;
+#import <vorbis/vorbisenc.h>
+#import <AVFAudioExtensions/AVFAudioExtensions.h>
 
 #import "SFBOggVorbisEncoder.h"
 

--- a/Sources/CSFBAudioEngine/Encoders/SFBWavPackEncoder.m
+++ b/Sources/CSFBAudioEngine/Encoders/SFBWavPackEncoder.m
@@ -4,12 +4,12 @@
 // MIT license
 //
 
-@import os.log;
+#import <os/log.h>
 
-@import AudioToolbox;
-@import CommonCrypto;
+#import <AudioToolbox/AudioToolbox.h>
+#import <CommonCrypto/CommonCrypto.h>
 
-@import wavpack;
+#import <wavpack/wavpack.h>
 
 #import "SFBWavPackEncoder.h"
 

--- a/Sources/CSFBAudioEngine/Metadata/SFBAudioFile.m
+++ b/Sources/CSFBAudioEngine/Metadata/SFBAudioFile.m
@@ -4,7 +4,7 @@
 // MIT license
 //
 
-@import os.log;
+#import <os/log.h>
 
 #import "SFBAudioFile.h"
 #import "SFBAudioFile+Internal.h"

--- a/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
+++ b/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
@@ -15,7 +15,7 @@
 #import <CXXCoreAudio/CAChannelLayout.hpp>
 #import <CXXCoreAudio/CAStreamDescription.hpp>
 
-#import <AVAudioFormat+SFBFormatTransformation.h>
+#import <AVFAudioExtensions/AVFAudioExtensions.h>
 
 #import "AudioPlayer.h"
 

--- a/Sources/CSFBAudioEngine/Utilities/SFBLibsndfileUtilities.m
+++ b/Sources/CSFBAudioEngine/Utilities/SFBLibsndfileUtilities.m
@@ -4,7 +4,7 @@
 // MIT license
 //
 
-@import sndfile;
+#import <sndfile/sndfile.h>
 
 #import "SFBAudioEngineTypes.h"
 #import "SFBLibsndfileUtilities.h"


### PR DESCRIPTION
## Pull request overview

This PR converts all Objective-C module imports (`@import`) to traditional header imports (`#import`) throughout the codebase, along with updating the AVFAudioExtensions dependency to version 0.5.0.

**Changes:**
- Converted all `@import` statements to `#import` with proper framework/header.h paths
- Consolidated AVFAudioExtensions imports to use the umbrella header
- Updated AVFAudioExtensions dependency from 0.4.2 to 0.5.0
- Removed TODO comments about module import diagnostic warnings (no longer relevant)