### PR TITLE
Add clang-format check workflow

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -4,6 +4,8 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+permissions:
+  contents: read
 jobs:
   formatting-check:
     name: Formatting Check


### PR DESCRIPTION
## Pull request overview

This pull request adds a GitHub Actions workflow to automatically check code formatting using clang-format for the C/Objective-C code in the repository.

**Changes:**
- Adds a new GitHub Actions workflow that runs clang-format on the CSFBAudioEngine source directory on pushes and pull requests to the main branch