### PR TITLE
Delete move construction and assignment

### DIFF
--- a/Sources/CSFBAudioEngine/Player/AudioPlayer.h
+++ b/Sources/CSFBAudioEngine/Player/AudioPlayer.h
@@ -108,8 +108,8 @@ class AudioPlayer final {
     AudioPlayer(const AudioPlayer&) = delete;
     AudioPlayer& operator=(const AudioPlayer&) = delete;
 
-    //    AudioPlayer(AudioPlayer&&) = delete;
-    //    AudioPlayer& operator=(AudioPlayer&&) = delete;
+    AudioPlayer(AudioPlayer&&) = delete;
+    AudioPlayer& operator=(AudioPlayer&&) = delete;
 
     ~AudioPlayer() noexcept;
 


### PR DESCRIPTION
## Pull request overview

This PR makes `sfb::AudioPlayer` explicitly non-movable by deleting its move constructor and move assignment operator.

**Changes:**
- Replace commented-out move deletion declarations with explicit `= delete` declarations for move construction and move assignment.