### PR TITLE
Miscellaneous code cleanup

### DIFF
--- a/Sources/CSFBAudioEngine/Analysis/SFBReplayGainAnalyzer.m
+++ b/Sources/CSFBAudioEngine/Analysis/SFBReplayGainAnalyzer.m
@@ -581,7 +581,7 @@ static float AnalyzeResult(const uint32_t *array, size_t len) {
         }
 
         // The replay gain analyzer expects 16-bit sample size passed as floats
-        const float scale = 1U << 15;
+        const float scale = 1u << 15;
         vDSP_vsmul(outputBuffer.floatChannelData[0], 1, &scale, outputBuffer.floatChannelData[0], 1,
                    (vDSP_Length)frameCount);
         if (isStereo) {

--- a/Sources/CSFBAudioEngine/Decoders/SFBDSDPCMDecoder.mm
+++ b/Sources/CSFBAudioEngine/Decoders/SFBDSDPCMDecoder.mm
@@ -460,7 +460,8 @@ class DXD {
 
         float *const *floatChannelData = buffer.floatChannelData;
         AVAudioChannelCount channelCount = buffer.format.channelCount;
-        bool isBigEndian = _buffer.format.streamDescription->mFormatFlags & kAudioFormatFlagIsBigEndian;
+        const bool isBigEndian = (_buffer.format.streamDescription->mFormatFlags & kAudioFormatFlagIsBigEndian) ==
+                                 kAudioFormatFlagIsBigEndian;
         for (AVAudioChannelCount channel = 0; channel < channelCount; ++channel) {
             const auto *const input = static_cast<const unsigned char *>(_buffer.data) + channel;
             float *output = floatChannelData[channel];

--- a/Sources/CSFBAudioEngine/Decoders/SFBDoPDecoder.m
+++ b/Sources/CSFBAudioEngine/Decoders/SFBDoPDecoder.m
@@ -136,7 +136,7 @@ static BOOL IsSupportedDoPSampleRate(Float64 sampleRate) {
         return NO;
     }
 
-    _reverseBits = !(asbd->mFormatFlags & kAudioFormatFlagIsBigEndian);
+    _reverseBits = (asbd->mFormatFlags & kAudioFormatFlagIsBigEndian) == 0;
 
     // Generate non-interleaved 24-bit big endian output
     AudioStreamBasicDescription processingStreamDescription = {0};

--- a/Sources/CSFBAudioEngine/Decoders/SFBFLACDecoder.mm
+++ b/Sources/CSFBAudioEngine/Decoders/SFBFLACDecoder.mm
@@ -434,10 +434,13 @@ void errorCallback(const FLAC__StreamDecoder *decoder, FLAC__StreamDecoderErrorS
             os_log_error(gSFBAudioDecoderLog, "FLAC__stream_decoder_process_single failed: %{public}s",
                          FLAC__stream_decoder_get_resolved_state_string(_flac.get()));
             if (error) {
-                *error = _writeError
-                               ?: [NSError errorWithDomain:SFBAudioDecoderErrorDomain
-                                                      code:SFBAudioDecoderErrorCodeDecodingError
-                                                  userInfo:@{NSURLErrorKey : _inputSource.url}];
+                if (_writeError) {
+                    *error = _writeError;
+                } else {
+                    *error = [NSError errorWithDomain:SFBAudioDecoderErrorDomain
+                                                 code:SFBAudioDecoderErrorCodeDecodingError
+                                             userInfo:@{NSURLErrorKey : _inputSource.url}];
+                }
             }
             return NO;
         }

--- a/Sources/CSFBAudioEngine/Decoders/SFBMonkeysAudioDecoder.mm
+++ b/Sources/CSFBAudioEngine/Decoders/SFBMonkeysAudioDecoder.mm
@@ -112,23 +112,23 @@ class APEIOInterface final : public APE::IAPEIO {
         case APE::SeekFileBegin:
             // offset remains unchanged
             break;
-        case APE::SeekFileCurrent: {
-            NSInteger inputSourceOffset;
-            if ([inputSource_ getOffset:&inputSourceOffset error:nil]) {
+        case APE::SeekFileCurrent:
+            if (NSInteger inputSourceOffset; [inputSource_ getOffset:&inputSourceOffset error:nil]) {
                 offset += inputSourceOffset;
             }
             break;
-        }
-        case APE::SeekFileEnd: {
-            NSInteger inputSourceLength;
-            if ([inputSource_ getLength:&inputSourceLength error:nil]) {
+        case APE::SeekFileEnd:
+            if (NSInteger inputSourceLength; [inputSource_ getLength:&inputSourceLength error:nil]) {
                 offset += inputSourceLength;
             }
             break;
         }
+
+        if (![inputSource_ seekToOffset:offset error:nil]) {
+            return ERROR_IO_READ;
         }
 
-        return ![inputSource_ seekToOffset:offset error:nil];
+        return ERROR_SUCCESS;
     }
 
     int Create(const wchar_t *pName) override {
@@ -410,7 +410,7 @@ class APEIOInterface final : public APE::IAPEIO {
 
     int64_t blocksRead = 0;
     if (_decompressor->GetData(static_cast<unsigned char *>(buffer.audioBufferList->mBuffers[0].mData),
-                               static_cast<int64_t>(frameLength), &blocksRead)) {
+                               static_cast<int64_t>(frameLength), &blocksRead) != ERROR_SUCCESS) {
         os_log_error(gSFBAudioDecoderLog, "Monkey's Audio invalid checksum");
         if (error) {
             *error = [NSError errorWithDomain:SFBAudioDecoderErrorDomain

--- a/Sources/CSFBAudioEngine/Decoders/SFBMusepackDecoder.m
+++ b/Sources/CSFBAudioEngine/Decoders/SFBMusepackDecoder.m
@@ -327,8 +327,8 @@ static mpc_bool_t canseek_callback(mpc_reader *p_reader) {
 #error "Fixed point not yet supported"
 #else
         // Clip the samples to [-1, 1)
-        float minValue = -1.F;
-        float maxValue = 8388607.F / 8388608.F;
+        float minValue = -1.f;
+        float maxValue = 8388607.f / 8388608.f;
 
         AVAudioChannelCount channelCount = _buffer.format.channelCount;
         vDSP_vclip((float *)frame.buffer, 1, &minValue, &maxValue, (float *)frame.buffer, 1,

--- a/Sources/CSFBAudioEngine/Decoders/SFBOggSpeexDecoder.m
+++ b/Sources/CSFBAudioEngine/Decoders/SFBOggSpeexDecoder.m
@@ -533,7 +533,7 @@ SFBAudioDecodingPropertiesKey const SFBAudioDecodingPropertiesKeyOggSpeexExtraHe
                             }
 
                             // Normalize the values
-                            float maxSampleValue = 1U << 15;
+                            float maxSampleValue = 1u << 15;
                             vDSP_vsdiv(buf, 1, &maxSampleValue, buf, 1,
                                        (vDSP_Length)speexFrameSize * _processingFormat.channelCount);
 

--- a/Sources/CSFBAudioEngine/Encoders/SFBAudioEncoder.m
+++ b/Sources/CSFBAudioEngine/Encoders/SFBAudioEncoder.m
@@ -272,7 +272,7 @@ static NSMutableArray *_registeredSubclasses = nil;
     }
 
     AVAudioFormat *processingFormat = [self processingFormatForSourceFormat:sourceFormat];
-    if (processingFormat == nil) {
+    if (!processingFormat) {
         os_log_error(gSFBAudioEncoderLog, "-setSourceFormat:error: called with invalid format: %{public}@",
                      sourceFormat);
         if (error) {

--- a/Sources/CSFBAudioEngine/Encoders/SFBCoreAudioEncoder.mm
+++ b/Sources/CSFBAudioEngine/Encoders/SFBCoreAudioEncoder.mm
@@ -358,8 +358,8 @@ OSStatus setSizeProc(void *inClientData, SInt64 inSize) noexcept {
     }
 
     AudioFileTypeID fileType = 0;
-    NSNumber *fileTypeSetting = [_settings objectForKey:SFBAudioEncodingSettingsKeyCoreAudioFileTypeID];
-    if (fileTypeSetting != nil) {
+    if (NSNumber *fileTypeSetting = [_settings objectForKey:SFBAudioEncodingSettingsKeyCoreAudioFileTypeID];
+        fileTypeSetting) {
         fileType = static_cast<AudioFileTypeID>(fileTypeSetting.unsignedIntValue);
     } else {
         auto typesForExtension = typeIDsForExtension(_outputSource.url.pathExtension);
@@ -390,8 +390,8 @@ OSStatus setSizeProc(void *inClientData, SInt64 inSize) noexcept {
     }
 
     AudioFormatID formatID = 0;
-    NSNumber *formatIDSetting = [_settings objectForKey:SFBAudioEncodingSettingsKeyCoreAudioFormatID];
-    if (formatIDSetting != nil) {
+    if (NSNumber *formatIDSetting = [_settings objectForKey:SFBAudioEncodingSettingsKeyCoreAudioFormatID];
+        formatIDSetting) {
         formatID = static_cast<AudioFormatID>(formatIDSetting.unsignedIntValue);
     } else {
         auto availableFormatIDs = formatIDsForFileTypeID(fileType, true);
@@ -427,8 +427,8 @@ OSStatus setSizeProc(void *inClientData, SInt64 inSize) noexcept {
     }
 
     UInt32 formatFlags = 0;
-    NSNumber *formatFlagsSetting = [_settings objectForKey:SFBAudioEncodingSettingsKeyCoreAudioFormatFlags];
-    if (formatFlagsSetting != nil) {
+    if (NSNumber *formatFlagsSetting = [_settings objectForKey:SFBAudioEncodingSettingsKeyCoreAudioFormatFlags];
+        formatFlagsSetting) {
         formatFlags = static_cast<UInt32>(formatFlagsSetting.unsignedIntValue);
     } else {
         os_log_info(gSFBAudioEncoderLog, "SFBAudioEncodingSettingsKeyCoreAudioFormatFlags is not set; mFormatFlags "
@@ -436,8 +436,8 @@ OSStatus setSizeProc(void *inClientData, SInt64 inSize) noexcept {
     }
 
     UInt32 bitsPerChannel = 0;
-    NSNumber *bitsPerChannelSetting = [_settings objectForKey:SFBAudioEncodingSettingsKeyCoreAudioBitsPerChannel];
-    if (bitsPerChannelSetting != nil) {
+    if (NSNumber *bitsPerChannelSetting = [_settings objectForKey:SFBAudioEncodingSettingsKeyCoreAudioBitsPerChannel];
+        bitsPerChannelSetting) {
         bitsPerChannel = static_cast<UInt32>(bitsPerChannelSetting.unsignedIntValue);
     } else {
         os_log_info(gSFBAudioEncoderLog, "SFBAudioEncodingSettingsKeyCoreAudioBitsPerChannel is not set; "
@@ -536,9 +536,9 @@ OSStatus setSizeProc(void *inClientData, SInt64 inSize) noexcept {
         }
     }
 
-    NSDictionary *audioConverterPropertySettings =
-          [_settings objectForKey:SFBAudioEncodingSettingsKeyCoreAudioAudioConverterPropertySettings];
-    if (audioConverterPropertySettings != nil) {
+    if (NSDictionary *audioConverterPropertySettings =
+              [_settings objectForKey:SFBAudioEncodingSettingsKeyCoreAudioAudioConverterPropertySettings];
+        audioConverterPropertySettings) {
         AudioConverterRef audioConverter = nullptr;
         UInt32 size = sizeof(audioConverter);
         result = ExtAudioFileGetProperty(extAudioFile, kExtAudioFileProperty_AudioConverter, &size, &audioConverter);

--- a/Sources/CSFBAudioEngine/Encoders/SFBFLACEncoder.mm
+++ b/Sources/CSFBAudioEngine/Encoders/SFBFLACEncoder.mm
@@ -178,8 +178,8 @@ void metadataCallback(const FLAC__StreamEncoder *encoder, const FLAC__StreamMeta
     NSParameterAssert(sourceFormat != nil);
 
     // Validate format
-    if (sourceFormat.streamDescription->mFormatFlags & kAudioFormatFlagIsFloat || sourceFormat.channelCount < 1 ||
-        sourceFormat.channelCount > 8) {
+    if ((sourceFormat.streamDescription->mFormatFlags & kAudioFormatFlagIsFloat) == kAudioFormatFlagIsFloat ||
+        sourceFormat.channelCount < 1 || sourceFormat.channelCount > 8) {
         return nil;
     }
 
@@ -261,8 +261,8 @@ void metadataCallback(const FLAC__StreamEncoder *encoder, const FLAC__StreamMeta
     }
 
     // Encoder compression level
-    NSNumber *compressionLevel = [_settings objectForKey:SFBAudioEncodingSettingsKeyFLACCompressionLevel];
-    if (compressionLevel != nil) {
+    if (NSNumber *compressionLevel = [_settings objectForKey:SFBAudioEncodingSettingsKeyFLACCompressionLevel];
+        compressionLevel) {
         unsigned int value = compressionLevel.unsignedIntValue;
         switch (value) {
         case 0 ... 8:
@@ -284,7 +284,7 @@ void metadataCallback(const FLAC__StreamEncoder *encoder, const FLAC__StreamMeta
     }
 
     if (NSNumber *verifyEncoding = [_settings objectForKey:SFBAudioEncodingSettingsKeyFLACVerifyEncoding];
-        verifyEncoding != nil) {
+        verifyEncoding) {
         FLAC__stream_encoder_set_verify(flac.get(), verifyEncoding.boolValue != 0);
     }
 

--- a/Sources/CSFBAudioEngine/Encoders/SFBLibsndfileEncoder.m
+++ b/Sources/CSFBAudioEngine/Encoders/SFBLibsndfileEncoder.m
@@ -132,7 +132,7 @@ static int InferSubtypeFromFormat(AVAudioFormat *format) {
         return 0;
     }
 
-    if (asbd->mFormatFlags & kAudioFormatFlagIsFloat) {
+    if ((asbd->mFormatFlags & kAudioFormatFlagIsFloat) == kAudioFormatFlagIsFloat) {
         if (asbd->mBitsPerChannel == 32) {
             return SF_FORMAT_FLOAT;
         }
@@ -140,25 +140,27 @@ static int InferSubtypeFromFormat(AVAudioFormat *format) {
             return SF_FORMAT_DOUBLE;
         }
     } else {
+        BOOL isSignedInteger =
+              (asbd->mFormatFlags & kAudioFormatFlagIsSignedInteger) == kAudioFormatFlagIsSignedInteger;
         switch (asbd->mBitsPerChannel) {
         case 8:
-            if (asbd->mFormatFlags & kAudioFormatFlagIsSignedInteger) {
+            if (isSignedInteger) {
                 return SF_FORMAT_PCM_S8;
             } else {
                 return SF_FORMAT_PCM_U8;
             }
         case 16:
-            if (asbd->mFormatFlags & kAudioFormatFlagIsSignedInteger) {
+            if (isSignedInteger) {
                 return SF_FORMAT_PCM_16;
             }
             break;
         case 24:
-            if (asbd->mFormatFlags & kAudioFormatFlagIsSignedInteger) {
+            if (isSignedInteger) {
                 return SF_FORMAT_PCM_24;
             }
             break;
         case 32:
-            if (asbd->mFormatFlags & kAudioFormatFlagIsSignedInteger) {
+            if (isSignedInteger) {
                 return SF_FORMAT_PCM_32;
             }
             break;
@@ -557,7 +559,7 @@ static sf_count_t my_sf_vio_tell(void *user_data) {
     }
 
     // Floating point
-    if (asbd->mFormatFlags & kAudioFormatFlagIsFloat) {
+    if ((asbd->mFormatFlags & kAudioFormatFlagIsFloat) == kAudioFormatFlagIsFloat) {
         if (asbd->mBitsPerChannel == 32) {
             return [sourceFormat transformedToCommonFormat:AVAudioPCMFormatFloat32 interleaved:YES];
         }
@@ -599,7 +601,7 @@ static sf_count_t my_sf_vio_tell(void *user_data) {
     int majorFormat = 0;
     SFBAudioEncodingSettingsValue majorFormatSetting =
           [_settings objectForKey:SFBAudioEncodingSettingsKeyLibsndfileMajorFormat];
-    if (majorFormatSetting != nil) {
+    if (majorFormatSetting) {
         if (majorFormatSetting == SFBAudioEncodingSettingsValueLibsndfileMajorFormatWAV) {
             majorFormat = SF_FORMAT_WAV;
         } else if (majorFormatSetting == SFBAudioEncodingSettingsValueLibsndfileMajorFormatAIFF) {
@@ -667,7 +669,7 @@ static sf_count_t my_sf_vio_tell(void *user_data) {
     int subtype = 0;
     SFBAudioEncodingSettingsValue subtypeSetting =
           [_settings objectForKey:SFBAudioEncodingSettingsKeyLibsndfileSubtype];
-    if (subtypeSetting != nil) {
+    if (subtypeSetting) {
         if (subtypeSetting == SFBAudioEncodingSettingsValueLibsndfileSubtypePCM_S8) {
             subtype = SF_FORMAT_PCM_S8;
         } else if (subtypeSetting == SFBAudioEncodingSettingsValueLibsndfileSubtypePCM_16) {
@@ -742,7 +744,7 @@ static sf_count_t my_sf_vio_tell(void *user_data) {
 
     int endian = 0;
     NSNumber *fileEndianSetting = [_settings objectForKey:SFBAudioEncodingSettingsKeyLibsndfileFileEndian];
-    if (fileEndianSetting != nil) {
+    if (fileEndianSetting) {
         if (fileEndianSetting == SFBAudioEncodingSettingsValueLibsndfileFileEndianDefault) {
             endian = SF_ENDIAN_FILE;
         } else if (fileEndianSetting == SFBAudioEncodingSettingsValueLibsndfileFileEndianLittle) {

--- a/Sources/CSFBAudioEngine/Encoders/SFBMP3Encoder.mm
+++ b/Sources/CSFBAudioEngine/Encoders/SFBMP3Encoder.mm
@@ -133,8 +133,7 @@ using lame_global_flags_unique_ptr = std::unique_ptr<lame_global_flags, lame_glo
     // Adjust encoder settings
 
     // Noise shaping and psychoacoustics
-    NSNumber *quality = [_settings objectForKey:SFBAudioEncodingSettingsKeyMP3Quality];
-    if (quality != nil) {
+    if (NSNumber *quality = [_settings objectForKey:SFBAudioEncodingSettingsKeyMP3Quality]; quality) {
         auto quality_value = quality.intValue;
         switch (quality_value) {
         case 0 ... 9:
@@ -157,7 +156,7 @@ using lame_global_flags_unique_ptr = std::unique_ptr<lame_global_flags, lame_glo
 
     // Constant bitrate encoding
     NSNumber *cbr = [_settings objectForKey:SFBAudioEncodingSettingsKeyMP3ConstantBitrate];
-    if (cbr != nil) {
+    if (cbr) {
         result = lame_set_VBR(gfp.get(), vbr_off);
         if (result == -1) {
             os_log_error(gSFBAudioEncoderLog, "lame_set_VBR(vbr_off) failed");
@@ -183,8 +182,8 @@ using lame_global_flags_unique_ptr = std::unique_ptr<lame_global_flags, lame_glo
 
     // Average bitrate encoding
     NSNumber *abr = [_settings objectForKey:SFBAudioEncodingSettingsKeyMP3AverageBitrate];
-    if (abr != nil) {
-        if (cbr != nil) {
+    if (abr) {
+        if (cbr) {
             os_log_info(gSFBAudioEncoderLog, "CBR and ABR bitrates both specified; this is probably not correct");
         }
 
@@ -222,11 +221,11 @@ using lame_global_flags_unique_ptr = std::unique_ptr<lame_global_flags, lame_glo
     // Variable bitrate encoding
     NSNumber *vbr = [_settings objectForKey:SFBAudioEncodingSettingsKeyMP3UseVariableBitrate];
     if (vbr.boolValue) {
-        if (cbr != nil) {
+        if (cbr) {
             os_log_info(gSFBAudioEncoderLog,
                         "VBR encoding and CBR bitrate both specified; this is probably not correct");
         }
-        if (abr != nil) {
+        if (abr) {
             os_log_info(gSFBAudioEncoderLog,
                         "VBR encoding and ABR bitrate both specified; this is probably not correct");
         }
@@ -242,8 +241,7 @@ using lame_global_flags_unique_ptr = std::unique_ptr<lame_global_flags, lame_glo
             return NO;
         }
 
-        NSNumber *vbrQuality = [_settings objectForKey:SFBAudioEncodingSettingsKeyMP3VBRQuality];
-        if (vbrQuality != nil) {
+        if (NSNumber *vbrQuality = [_settings objectForKey:SFBAudioEncodingSettingsKeyMP3VBRQuality]; vbrQuality) {
             result = lame_set_VBR_quality(gfp.get(), vbrQuality.floatValue);
             if (result == -1) {
                 os_log_error(gSFBAudioEncoderLog, "lame_set_VBR_quality(%g) failed", vbrQuality.floatValue);
@@ -256,8 +254,7 @@ using lame_global_flags_unique_ptr = std::unique_ptr<lame_global_flags, lame_glo
             }
         }
 
-        NSNumber *vbrMin = [_settings objectForKey:SFBAudioEncodingSettingsKeyMP3VBRMinimumBitrate];
-        if (vbrMin != nil) {
+        if (NSNumber *vbrMin = [_settings objectForKey:SFBAudioEncodingSettingsKeyMP3VBRMinimumBitrate]; vbrMin) {
             result = lame_set_brate(gfp.get(), vbrMin.intValue);
             if (result == -1) {
                 os_log_error(gSFBAudioEncoderLog, "lame_set_brate(%d) failed", vbrMin.intValue);
@@ -282,8 +279,7 @@ using lame_global_flags_unique_ptr = std::unique_ptr<lame_global_flags, lame_glo
             }
         }
 
-        NSNumber *vbrMax = [_settings objectForKey:SFBAudioEncodingSettingsKeyMP3VBRMaximumBitrate];
-        if (vbrMax != nil) {
+        if (NSNumber *vbrMax = [_settings objectForKey:SFBAudioEncodingSettingsKeyMP3VBRMaximumBitrate]; vbrMax) {
             auto bitrate = vbrMax.intValue * 1000;
             result = lame_set_VBR_max_bitrate_kbps(gfp.get(), bitrate);
             if (result == -1) {
@@ -298,8 +294,8 @@ using lame_global_flags_unique_ptr = std::unique_ptr<lame_global_flags, lame_glo
         }
     }
 
-    SFBAudioEncodingSettingsValue stereoMode = [_settings objectForKey:SFBAudioEncodingSettingsKeyMP3StereoMode];
-    if (stereoMode != nil) {
+    if (SFBAudioEncodingSettingsValue stereoMode = [_settings objectForKey:SFBAudioEncodingSettingsKeyMP3StereoMode];
+        stereoMode) {
         if (stereoMode == SFBAudioEncodingSettingsValueMP3StereoModeMono) {
             result = lame_set_mode(gfp.get(), MONO);
         } else if (stereoMode == SFBAudioEncodingSettingsValueMP3StereoModeStereo) {

--- a/Sources/CSFBAudioEngine/Encoders/SFBMonkeysAudioEncoder.mm
+++ b/Sources/CSFBAudioEngine/Encoders/SFBMonkeysAudioEncoder.mm
@@ -88,23 +88,23 @@ class APEIOInterface final : public APE::IAPEIO {
         case APE::SeekFileBegin:
             // offset remains unchanged
             break;
-        case APE::SeekFileCurrent: {
-            NSInteger inputSourceOffset;
-            if ([outputSource_ getOffset:&inputSourceOffset error:nil]) {
+        case APE::SeekFileCurrent:
+            if (NSInteger inputSourceOffset; [outputSource_ getOffset:&inputSourceOffset error:nil]) {
                 offset += inputSourceOffset;
             }
             break;
-        }
-        case APE::SeekFileEnd: {
-            NSInteger inputSourceLength;
-            if ([outputSource_ getLength:&inputSourceLength error:nil]) {
+        case APE::SeekFileEnd:
+            if (NSInteger inputSourceLength; [outputSource_ getLength:&inputSourceLength error:nil]) {
                 offset += inputSourceLength;
             }
             break;
         }
+
+        if (![outputSource_ seekToOffset:offset error:nil]) {
+            return ERROR_IO_READ;
         }
 
-        return ![outputSource_ seekToOffset:offset error:nil];
+        return ERROR_SUCCESS;
     }
 
     int Create(const wchar_t *pName) override {
@@ -186,8 +186,8 @@ class APEIOInterface final : public APE::IAPEIO {
     NSParameterAssert(sourceFormat != nil);
 
     // Validate format
-    if (sourceFormat.streamDescription->mFormatFlags & kAudioFormatFlagIsFloat || sourceFormat.channelCount < 1 ||
-        sourceFormat.channelCount > 32) {
+    if ((sourceFormat.streamDescription->mFormatFlags & kAudioFormatFlagIsFloat) == kAudioFormatFlagIsFloat ||
+        sourceFormat.channelCount < 1 || sourceFormat.channelCount > 32) {
         return nil;
     }
 

--- a/Sources/CSFBAudioEngine/Encoders/SFBMusepackEncoder.m
+++ b/Sources/CSFBAudioEngine/Encoders/SFBMusepackEncoder.m
@@ -154,7 +154,7 @@ static off_t my_mpc_tell_callback(void *context) {
     }
 
     NSNumber *quality = [_settings objectForKey:SFBAudioEncodingSettingsKeyMusepackQuality];
-    if (quality != nil) {
+    if (quality) {
         float quality_value = quality.floatValue;
         if (quality_value < 0 || quality_value > 10) {
             os_log_info(gSFBAudioEncoderLog, "Ignoring invalid Musepack quality: %g", quality_value);

--- a/Sources/CSFBAudioEngine/Encoders/SFBOggOpusEncoder.mm
+++ b/Sources/CSFBAudioEngine/Encoders/SFBOggOpusEncoder.mm
@@ -209,8 +209,7 @@ int closeCallback(void *user_data) noexcept {
         return NO;
     }
 
-    NSNumber *bitrate = [_settings objectForKey:SFBAudioEncodingSettingsKeyOpusBitrate];
-    if (bitrate != nil) {
+    if (NSNumber *bitrate = [_settings objectForKey:SFBAudioEncodingSettingsKeyOpusBitrate]; bitrate) {
         opus_int32 intValue = bitrate.intValue;
         switch (intValue) {
         case 6 ... 256:
@@ -234,8 +233,8 @@ int closeCallback(void *user_data) noexcept {
         }
     }
 
-    SFBAudioEncodingSettingsValue bitrateMode = [_settings objectForKey:SFBAudioEncodingSettingsKeyOpusBitrateMode];
-    if (bitrateMode != nil) {
+    if (SFBAudioEncodingSettingsValue bitrateMode = [_settings objectForKey:SFBAudioEncodingSettingsKeyOpusBitrateMode];
+        bitrateMode) {
         if (bitrateMode == SFBAudioEncodingSettingsValueOpusBitrateModeVBR) {
             result = ope_encoder_ctl(enc.get(), OPUS_SET_VBR(1));
         } else if (bitrateMode == SFBAudioEncodingSettingsValueOpusBitrateModeConstrainedVBR) {
@@ -257,8 +256,7 @@ int closeCallback(void *user_data) noexcept {
         }
     }
 
-    NSNumber *complexity = [_settings objectForKey:SFBAudioEncodingSettingsKeyOpusComplexity];
-    if (complexity != nil) {
+    if (NSNumber *complexity = [_settings objectForKey:SFBAudioEncodingSettingsKeyOpusComplexity]; complexity) {
         int intValue = complexity.intValue;
         switch (intValue) {
         case 0 ... 10:
@@ -280,8 +278,8 @@ int closeCallback(void *user_data) noexcept {
         }
     }
 
-    SFBAudioEncodingSettingsValue signalType = [_settings objectForKey:SFBAudioEncodingSettingsKeyOpusSignalType];
-    if (signalType != nil) {
+    if (SFBAudioEncodingSettingsValue signalType = [_settings objectForKey:SFBAudioEncodingSettingsKeyOpusSignalType];
+        signalType) {
         if (signalType == SFBAudioEncodingSettingsValueOpusSignalTypeVoice) {
             result = ope_encoder_ctl(enc.get(), OPUS_SET_SIGNAL(OPUS_SIGNAL_VOICE));
         } else if (signalType == SFBAudioEncodingSettingsValueOpusSignalTypeMusic) {
@@ -304,8 +302,9 @@ int closeCallback(void *user_data) noexcept {
     // Default in opusenc.c
     AVAudioFrameCount frameCapacity = 960;
 
-    SFBAudioEncodingSettingsValue frameDuration = [_settings objectForKey:SFBAudioEncodingSettingsKeyOpusFrameDuration];
-    if (frameDuration != nil) {
+    if (SFBAudioEncodingSettingsValue frameDuration =
+              [_settings objectForKey:SFBAudioEncodingSettingsKeyOpusFrameDuration];
+        frameDuration) {
         if (frameDuration == SFBAudioEncodingSettingsValueOpusFrameDuration2_5ms) {
             frameCapacity = 120;
             result = ope_encoder_ctl(enc.get(), OPUS_SET_EXPERT_FRAME_DURATION(OPUS_FRAMESIZE_2_5_MS));

--- a/Sources/CSFBAudioEngine/Encoders/SFBOggSpeexEncoder.m
+++ b/Sources/CSFBAudioEngine/Encoders/SFBOggSpeexEncoder.m
@@ -136,7 +136,7 @@ static void vorbis_comment_add(char **comments, size_t *length, const char *tag,
     double sampleRate = sourceFormat.sampleRate;
 
     SFBAudioEncodingSettingsValue mode = [_settings objectForKey:SFBAudioEncodingSettingsKeySpeexMode];
-    if (mode != nil) {
+    if (mode) {
         // Determine the desired sample rate
         if (mode == SFBAudioEncodingSettingsValueSpeexModeNarrowband) {
             sampleRate = 8000;
@@ -182,7 +182,7 @@ static void vorbis_comment_add(char **comments, size_t *length, const char *tag,
     // Setup the encoder
     const SpeexMode *speex_mode = NULL;
     SFBAudioEncodingSettingsValue mode = [_settings objectForKey:SFBAudioEncodingSettingsKeySpeexMode];
-    if (mode == nil) {
+    if (!mode) {
         if (_processingFormat.sampleRate > 25000) {
             speex_mode = speex_lib_get_mode(SPEEX_MODEID_UWB);
         } else if (_processingFormat.sampleRate > 12500) {
@@ -244,7 +244,7 @@ static void vorbis_comment_add(char **comments, size_t *length, const char *tag,
     // Encoder mode
     if ([[_settings objectForKey:SFBAudioEncodingSettingsKeySpeexTargetIsBitrate] boolValue]) {
         NSNumber *bitrate = [_settings objectForKey:SFBAudioEncodingSettingsKeySpeexBitrate];
-        if (bitrate != nil) {
+        if (bitrate) {
             spx_int32_t bitrate_value = bitrate.intValue;
             speex_encoder_ctl(_st, SPEEX_SET_BITRATE, &bitrate_value);
         } else {
@@ -305,7 +305,7 @@ static void vorbis_comment_add(char **comments, size_t *length, const char *tag,
 
     _speex_frames_per_ogg_packet = 1; // 1-10 default 1
     NSNumber *framesPerPacket = [_settings objectForKey:SFBAudioEncodingSettingsKeySpeexFramesPerOggPacket] ?: @1;
-    if (framesPerPacket != nil) {
+    if (framesPerPacket) {
         int intValue = framesPerPacket.intValue;
         if (intValue < 1 || intValue > 10) {
             os_log_error(gSFBAudioEncoderLog, "Invalid Speex frames per packet: %d", intValue);

--- a/Sources/CSFBAudioEngine/Encoders/SFBOggVorbisEncoder.m
+++ b/Sources/CSFBAudioEngine/Encoders/SFBOggVorbisEncoder.m
@@ -90,7 +90,7 @@ SFBAudioEncodingSettingsKey const SFBAudioEncodingSettingsKeyVorbisMaxBitrate = 
         break;
     }
 
-    if (channelLayout == nil) {
+    if (!channelLayout) {
         return nil;
     }
 
@@ -127,9 +127,9 @@ SFBAudioEncodingSettingsKey const SFBAudioEncodingSettingsKeyVorbisMaxBitrate = 
         NSNumber *max_bitrate = [_settings objectForKey:SFBAudioEncodingSettingsKeyVorbisMaxBitrate];
 
         result = vorbis_encode_init(&_vi, _processingFormat.channelCount, (long)_processingFormat.sampleRate,
-                                    min_bitrate != nil ? min_bitrate.longValue * 1000 : -1,
-                                    nominal_bitrate != nil ? nominal_bitrate.longValue * 1000 : 128000,
-                                    max_bitrate != nil ? max_bitrate.longValue * 1000 : -1);
+                                    min_bitrate ? min_bitrate.longValue * 1000 : -1,
+                                    nominal_bitrate ? nominal_bitrate.longValue * 1000 : 128000,
+                                    max_bitrate ? max_bitrate.longValue * 1000 : -1);
         if (result != 0) {
             os_log_error(gSFBAudioEncoderLog, "vorbis_encode_init failed: %d", result);
             vorbis_info_clear(&_vi);
@@ -144,7 +144,7 @@ SFBAudioEncodingSettingsKey const SFBAudioEncodingSettingsKeyVorbisMaxBitrate = 
     } else {
         float quality_value = 0.5;
         NSNumber *quality = [_settings objectForKey:SFBAudioEncodingSettingsKeyVorbisQuality];
-        if (quality != nil) {
+        if (quality) {
             quality_value = MAX(-0.1F, MIN(1.0F, quality.floatValue));
         }
 

--- a/Sources/CSFBAudioEngine/Encoders/SFBTrueAudioEncoder.mm
+++ b/Sources/CSFBAudioEngine/Encoders/SFBTrueAudioEncoder.mm
@@ -76,7 +76,7 @@ TTAint64 seekCallback(struct _tag_TTA_io_callback *io, TTAint64 offset) noexcept
     NSParameterAssert(sourceFormat != nil);
 
     // Validate format
-    if (sourceFormat.streamDescription->mFormatFlags & kAudioFormatFlagIsFloat ||
+    if ((sourceFormat.streamDescription->mFormatFlags & kAudioFormatFlagIsFloat) == kAudioFormatFlagIsFloat ||
         sourceFormat.streamDescription->mBitsPerChannel < MIN_BPS ||
         sourceFormat.streamDescription->mBitsPerChannel > MAX_BPS || sourceFormat.channelCount < 1 ||
         sourceFormat.channelCount > MAX_NCH) {

--- a/Sources/CSFBAudioEngine/Encoders/SFBWavPackEncoder.m
+++ b/Sources/CSFBAudioEngine/Encoders/SFBWavPackEncoder.m
@@ -41,7 +41,7 @@ static int wavpack_block_output(void *id, void *data, int32_t bcount) {
     NSCParameterAssert(id != NULL);
     SFBWavPackEncoder *encoder = (__bridge SFBWavPackEncoder *)id;
 
-    if (encoder->_firstBlock == nil) {
+    if (!encoder->_firstBlock) {
         encoder->_firstBlock = [NSMutableData dataWithBytes:data length:(NSUInteger)bcount];
     }
 
@@ -75,8 +75,8 @@ static int wavpack_block_output(void *id, void *data, int32_t bcount) {
     NSParameterAssert(sourceFormat != nil);
 
     // Validate format
-    if (sourceFormat.streamDescription->mFormatFlags & kAudioFormatFlagIsFloat || sourceFormat.channelCount < 1 ||
-        sourceFormat.channelCount > 32) {
+    if ((sourceFormat.streamDescription->mFormatFlags & kAudioFormatFlagIsFloat) == kAudioFormatFlagIsFloat ||
+        sourceFormat.channelCount < 1 || sourceFormat.channelCount > 32) {
         return nil;
     }
 
@@ -101,7 +101,7 @@ static int wavpack_block_output(void *id, void *data, int32_t bcount) {
     // Use WAVFORMATEX channel order
     AVAudioChannelLayout *channelLayout = nil;
 
-    if (sourceFormat.channelLayout != nil) {
+    if (sourceFormat.channelLayout) {
         AudioChannelBitmap channelBitmap = 0;
         UInt32 propertySize = sizeof(channelBitmap);
         AudioChannelLayoutTag layoutTag = sourceFormat.channelLayout.layoutTag;
@@ -163,7 +163,7 @@ static int wavpack_block_output(void *id, void *data, int32_t bcount) {
     _config.flags = CONFIG_MD5_CHECKSUM;
 
     SFBAudioEncodingSettingsValue level = [_settings objectForKey:SFBAudioEncodingSettingsKeyWavPackCompressionLevel];
-    if (level != nil) {
+    if (level) {
         if (level == SFBAudioEncodingSettingsValueWavPackCompressionLevelFast) {
             _config.flags |= CONFIG_FAST_FLAG;
         } else if (level == SFBAudioEncodingSettingsValueWavPackCompressionLevelHigh) {

--- a/Sources/CSFBAudioEngine/Input/SFBFileContentsInputSource.m
+++ b/Sources/CSFBAudioEngine/Input/SFBFileContentsInputSource.m
@@ -13,7 +13,7 @@
     NSParameterAssert(url.isFileURL);
 
     NSData *data = [NSData dataWithContentsOfURL:url options:0 error:error];
-    if (data == nil) {
+    if (!data) {
         return nil;
     }
 

--- a/Sources/CSFBAudioEngine/Input/SFBInputSource.m
+++ b/Sources/CSFBAudioEngine/Input/SFBInputSource.m
@@ -76,7 +76,7 @@ static void SFBCreateInputSourceLog(void) {
     NSParameterAssert(bytes != NULL);
     NSParameterAssert(length >= 0);
     NSData *data = [NSData dataWithBytes:bytes length:(NSUInteger)length];
-    if (data == nil) {
+    if (!data) {
         return nil;
     }
     return [[SFBDataInputSource alloc] initWithData:data];
@@ -86,7 +86,7 @@ static void SFBCreateInputSourceLog(void) {
     NSParameterAssert(bytes != NULL);
     NSParameterAssert(length >= 0);
     NSData *data = [NSData dataWithBytesNoCopy:bytes length:(NSUInteger)length freeWhenDone:freeWhenDone];
-    if (data == nil) {
+    if (!data) {
         return nil;
     }
     return [[SFBDataInputSource alloc] initWithData:data];

--- a/Sources/CSFBAudioEngine/Input/SFBMemoryMappedFileInputSource.m
+++ b/Sources/CSFBAudioEngine/Input/SFBMemoryMappedFileInputSource.m
@@ -13,7 +13,7 @@
     NSParameterAssert(url.isFileURL);
 
     NSData *data = [NSData dataWithContentsOfURL:url options:NSDataReadingMappedAlways error:error];
-    if (data == nil) {
+    if (!data) {
         return nil;
     }
 

--- a/Sources/CSFBAudioEngine/Metadata/AddAudioPropertiesToDictionary.mm
+++ b/Sources/CSFBAudioEngine/Metadata/AddAudioPropertiesToDictionary.mm
@@ -9,22 +9,22 @@
 #import "SFBAudioProperties.h"
 
 void sfb::addAudioPropertiesToDictionary(const TagLib::AudioProperties *properties, NSMutableDictionary *dictionary) {
-    NSCParameterAssert(properties != nil);
-    NSCParameterAssert(dictionary != nil);
+    assert(properties != nil);
+    assert(dictionary != nil);
 
-    if (properties->lengthInMilliseconds()) {
+    if (properties->lengthInMilliseconds() != 0) {
         dictionary[SFBAudioPropertiesKeyDuration] = @(properties->lengthInMilliseconds() / 1000.0);
     }
 
-    if (properties->channels()) {
+    if (properties->channels() != 0) {
         dictionary[SFBAudioPropertiesKeyChannelCount] = @(properties->channels());
     }
 
-    if (properties->sampleRate()) {
+    if (properties->sampleRate() != 0) {
         dictionary[SFBAudioPropertiesKeySampleRate] = @(properties->sampleRate());
     }
 
-    if (properties->bitrate()) {
+    if (properties->bitrate() != 0) {
         dictionary[SFBAudioPropertiesKeyBitrate] = @(properties->bitrate());
     }
 }

--- a/Sources/CSFBAudioEngine/Metadata/SFBAIFFFile.mm
+++ b/Sources/CSFBAudioEngine/Metadata/SFBAIFFFile.mm
@@ -96,10 +96,10 @@ SFBAudioFileFormatName const SFBAudioFileFormatNameAIFF = @"org.sbooth.AudioEngi
             auto *properties = file.audioProperties();
             sfb::addAudioPropertiesToDictionary(properties, propertiesDictionary);
 
-            if (properties->bitsPerSample()) {
+            if (properties->bitsPerSample() != 0) {
                 propertiesDictionary[SFBAudioPropertiesKeyBitDepth] = @(properties->bitsPerSample());
             }
-            if (properties->sampleFrames()) {
+            if (properties->sampleFrames() != 0) {
                 propertiesDictionary[SFBAudioPropertiesKeyFrameLength] = @(properties->sampleFrames());
             }
         }

--- a/Sources/CSFBAudioEngine/Metadata/SFBAudioMetadata+TagLibAPETag.mm
+++ b/Sources/CSFBAudioEngine/Metadata/SFBAudioMetadata+TagLibAPETag.mm
@@ -112,7 +112,7 @@
                 [key caseInsensitiveCompare:@"Cover Art (Back)"] == NSOrderedSame) {
                 auto binaryData = item.binaryData();
                 auto pos = binaryData.find('\0');
-                if (-1 != pos && 3 < binaryData.size()) {
+                if (pos != -1 && binaryData.size() > 3) {
                     auto upos = static_cast<unsigned int>(pos);
                     NSData *imageData = [NSData dataWithBytes:binaryData.mid(upos + 1).data()
                                                        length:(binaryData.size() - upos - 1)];
@@ -130,7 +130,7 @@
         }
     }
 
-    if (additionalMetadata.count) {
+    if (additionalMetadata.count > 0) {
         self.additionalMetadata = additionalMetadata;
     }
 }
@@ -140,8 +140,8 @@
 namespace {
 
 void SetAPETag(TagLib::APE::Tag *tag, const char *key, NSString *value) {
-    assert(nullptr != tag);
-    assert(nullptr != key);
+    assert(tag != nullptr);
+    assert(key != nullptr);
 
     // Remove the existing comment with this name
     tag->removeItem(key);
@@ -152,17 +152,17 @@ void SetAPETag(TagLib::APE::Tag *tag, const char *key, NSString *value) {
 }
 
 void SetAPETagNumber(TagLib::APE::Tag *tag, const char *key, NSNumber *value) {
-    assert(nullptr != tag);
-    assert(nullptr != key);
+    assert(tag != nullptr);
+    assert(key != nullptr);
 
     SetAPETag(tag, key, value.stringValue);
 }
 
 void SetAPETagBoolean(TagLib::APE::Tag *tag, const char *key, NSNumber *value) {
-    assert(nullptr != tag);
-    assert(nullptr != key);
+    assert(tag != nullptr);
+    assert(key != nullptr);
 
-    if (value == nil) {
+    if (!value) {
         SetAPETag(tag, key, nil);
     } else {
         SetAPETag(tag, key, value.boolValue ? @"1" : @"0");
@@ -170,17 +170,25 @@ void SetAPETagBoolean(TagLib::APE::Tag *tag, const char *key, NSNumber *value) {
 }
 
 void SetAPETagDoubleWithFormat(TagLib::APE::Tag *tag, const char *key, NSNumber *value, NSString *format = nil) {
-    assert(nullptr != tag);
-    assert(nullptr != key);
+    assert(tag != nullptr);
+    assert(key != nullptr);
 
-    SetAPETag(tag, key, value != nil ? [NSString stringWithFormat:(format ?: @"%f"), value.doubleValue] : nil);
+    if (!value) {
+        SetAPETag(tag, key, nil);
+    } else {
+        if (!format) {
+            SetAPETag(tag, key, [NSString stringWithFormat:@"%f", value.doubleValue]);
+        } else {
+            SetAPETag(tag, key, [NSString stringWithFormat:format, value.doubleValue]);
+        }
+    }
 }
 
 } /* namespace */
 
 void sfb::setAPETagFromMetadata(SFBAudioMetadata *metadata, TagLib::APE::Tag *tag, bool setAlbumArt) {
-    NSCParameterAssert(metadata != nil);
-    assert(nullptr != tag);
+    assert(metadata != nil);
+    assert(tag != nullptr);
 
     // Standard tags
     SetAPETag(tag, "ALBUM", metadata.albumTitle);

--- a/Sources/CSFBAudioEngine/Metadata/SFBAudioMetadata+TagLibID3v2Tag.mm
+++ b/Sources/CSFBAudioEngine/Metadata/SFBAudioMetadata+TagLibID3v2Tag.mm
@@ -42,8 +42,7 @@ using cg_image_source_unique_ptr = std::unique_ptr<CGImageSource, cf_type_ref_de
     [self addMetadataFromTagLibTag:tag];
 
     // Release date
-    auto frameList = tag->frameListMap()["TDRC"];
-    if (!frameList.isEmpty()) {
+    if (auto frameList = tag->frameListMap()["TDRC"]; !frameList.isEmpty()) {
         /*
          The timestamp fields are based on a subset of ISO 8601. When being as
          precise as possible the format of a time string is
@@ -62,20 +61,17 @@ using cg_image_source_unique_ptr = std::unique_ptr<CGImageSource, cf_type_ref_de
     }
 
     // Extract composer if present
-    frameList = tag->frameListMap()["TCOM"];
-    if (!frameList.isEmpty()) {
+    if (auto frameList = tag->frameListMap()["TCOM"]; !frameList.isEmpty()) {
         self.composer = [NSString stringWithUTF8String:frameList.front()->toString().toCString(true)];
     }
 
     // Extract album artist
-    frameList = tag->frameListMap()["TPE2"];
-    if (!frameList.isEmpty()) {
+    if (auto frameList = tag->frameListMap()["TPE2"]; !frameList.isEmpty()) {
         self.albumArtist = [NSString stringWithUTF8String:frameList.front()->toString().toCString(true)];
     }
 
     // BPM
-    frameList = tag->frameListMap()["TBPM"];
-    if (!frameList.isEmpty()) {
+    if (auto frameList = tag->frameListMap()["TBPM"]; !frameList.isEmpty()) {
         bool ok = false;
         int BPM = frameList.front()->toString().toInt(&ok);
         if (ok) {
@@ -85,21 +81,20 @@ using cg_image_source_unique_ptr = std::unique_ptr<CGImageSource, cf_type_ref_de
 
     // Rating
     TagLib::ID3v2::PopularimeterFrame *popularimeter = nullptr;
-    frameList = tag->frameListMap()["POPM"];
-    if (!frameList.isEmpty() &&
-        nullptr != (popularimeter = dynamic_cast<TagLib::ID3v2::PopularimeterFrame *>(frameList.front()))) {
+    if (auto frameList = tag->frameListMap()["POPM"];
+        !frameList.isEmpty() &&
+        (popularimeter = dynamic_cast<TagLib::ID3v2::PopularimeterFrame *>(frameList.front())) != nullptr) {
         self.rating = @(popularimeter->rating());
     }
 
     // Extract total tracks if present
-    frameList = tag->frameListMap()["TRCK"];
-    if (!frameList.isEmpty()) {
+    if (auto frameList = tag->frameListMap()["TRCK"]; !frameList.isEmpty()) {
         // Split the tracks at '/'
         TagLib::String s = frameList.front()->toString();
 
         bool ok;
         auto pos = s.find("/", 0);
-        if (-1 != pos) {
+        if (pos != -1) {
             auto upos = static_cast<unsigned int>(pos);
             int trackNum = s.substr(0, upos).toInt(&ok);
             if (ok) {
@@ -110,7 +105,7 @@ using cg_image_source_unique_ptr = std::unique_ptr<CGImageSource, cf_type_ref_de
             if (ok) {
                 self.trackTotal = @(trackTotal);
             }
-        } else if (s.length()) {
+        } else if (s.length() > 0) {
             int trackNum = s.toInt(&ok);
             if (ok) {
                 self.trackNumber = @(trackNum);
@@ -119,14 +114,13 @@ using cg_image_source_unique_ptr = std::unique_ptr<CGImageSource, cf_type_ref_de
     }
 
     // Extract disc number and total discs
-    frameList = tag->frameListMap()["TPOS"];
-    if (!frameList.isEmpty()) {
+    if (auto frameList = tag->frameListMap()["TPOS"]; !frameList.isEmpty()) {
         // Split the tracks at '/'
         TagLib::String s = frameList.front()->toString();
 
         bool ok;
         auto pos = s.find("/", 0);
-        if (-1 != pos) {
+        if (pos != -1) {
             auto upos = static_cast<unsigned int>(pos);
             int discNum = s.substr(0, upos).toInt(&ok);
             if (ok) {
@@ -137,7 +131,7 @@ using cg_image_source_unique_ptr = std::unique_ptr<CGImageSource, cf_type_ref_de
             if (ok) {
                 self.discTotal = @(discTotal);
             }
-        } else if (s.length()) {
+        } else if (s.length() > 0) {
             int discNum = s.toInt(&ok);
             if (ok) {
                 self.discNumber = @(discNum);
@@ -146,71 +140,62 @@ using cg_image_source_unique_ptr = std::unique_ptr<CGImageSource, cf_type_ref_de
     }
 
     // Lyrics
-    frameList = tag->frameListMap()["USLT"];
-    if (!frameList.isEmpty()) {
+    if (auto frameList = tag->frameListMap()["USLT"]; !frameList.isEmpty()) {
         self.lyrics = [NSString stringWithUTF8String:frameList.front()->toString().toCString(true)];
     }
 
     // Extract compilation if present (iTunes TCMP tag)
-    frameList = tag->frameListMap()["TCMP"];
-    if (!frameList.isEmpty()) {
+    if (auto frameList = tag->frameListMap()["TCMP"]; !frameList.isEmpty()) {
         // It seems that the presence of this frame indicates a compilation
         self.compilation = @(YES);
     }
 
-    frameList = tag->frameListMap()["TSRC"];
-    if (!frameList.isEmpty()) {
+    if (auto frameList = tag->frameListMap()["TSRC"]; !frameList.isEmpty()) {
         self.isrc = [NSString stringWithUTF8String:frameList.front()->toString().toCString(true)];
     }
 
     // MusicBrainz
-    auto *musicBrainzReleaseIDFrame = TagLib::ID3v2::UserTextIdentificationFrame::find(
-          const_cast<TagLib::ID3v2::Tag *>(tag), "MusicBrainz Album Id");
-    if (musicBrainzReleaseIDFrame) {
+    if (auto *musicBrainzReleaseIDFrame = TagLib::ID3v2::UserTextIdentificationFrame::find(
+              const_cast<TagLib::ID3v2::Tag *>(tag), "MusicBrainz Album Id");
+        musicBrainzReleaseIDFrame) {
         self.musicBrainzReleaseID =
               [NSString stringWithUTF8String:musicBrainzReleaseIDFrame->fieldList().back().toCString(true)];
     }
 
-    auto *musicBrainzRecordingIDFrame = TagLib::ID3v2::UserTextIdentificationFrame::find(
-          const_cast<TagLib::ID3v2::Tag *>(tag), "MusicBrainz Track Id");
-    if (musicBrainzRecordingIDFrame) {
+    if (auto *musicBrainzRecordingIDFrame = TagLib::ID3v2::UserTextIdentificationFrame::find(
+              const_cast<TagLib::ID3v2::Tag *>(tag), "MusicBrainz Track Id");
+        musicBrainzRecordingIDFrame) {
         self.musicBrainzRecordingID =
               [NSString stringWithUTF8String:musicBrainzRecordingIDFrame->fieldList().back().toCString(true)];
     }
 
     // Sorting and grouping
-    frameList = tag->frameListMap()["TSOT"];
-    if (!frameList.isEmpty()) {
+    if (auto frameList = tag->frameListMap()["TSOT"]; !frameList.isEmpty()) {
         self.titleSortOrder = [NSString stringWithUTF8String:frameList.front()->toString().toCString(true)];
     }
 
-    frameList = tag->frameListMap()["TSOA"];
-    if (!frameList.isEmpty()) {
+    if (auto frameList = tag->frameListMap()["TSOA"]; !frameList.isEmpty()) {
         self.albumTitleSortOrder = [NSString stringWithUTF8String:frameList.front()->toString().toCString(true)];
     }
 
-    frameList = tag->frameListMap()["TSOP"];
-    if (!frameList.isEmpty()) {
+    if (auto frameList = tag->frameListMap()["TSOP"]; !frameList.isEmpty()) {
         self.artistSortOrder = [NSString stringWithUTF8String:frameList.front()->toString().toCString(true)];
     }
 
-    frameList = tag->frameListMap()["TSO2"];
-    if (!frameList.isEmpty()) {
+    if (auto frameList = tag->frameListMap()["TSO2"]; !frameList.isEmpty()) {
         self.albumArtistSortOrder = [NSString stringWithUTF8String:frameList.front()->toString().toCString(true)];
     }
 
-    frameList = tag->frameListMap()["TSOC"];
-    if (!frameList.isEmpty()) {
+    if (auto frameList = tag->frameListMap()["TSOC"]; !frameList.isEmpty()) {
         self.composerSortOrder = [NSString stringWithUTF8String:frameList.front()->toString().toCString(true)];
     }
 
-    frameList = tag->frameListMap()["TIT1"];
-    if (!frameList.isEmpty()) {
+    if (auto frameList = tag->frameListMap()["TIT1"]; !frameList.isEmpty()) {
         self.grouping = [NSString stringWithUTF8String:frameList.front()->toString().toCString(true)];
     }
 
     // ReplayGain
-    bool foundReplayGain = false;
+    auto foundReplayGain = false;
 
     // Preference is TXXX frames, RVA2 frame, then LAME header
     auto *trackGainFrame = TagLib::ID3v2::UserTextIdentificationFrame::find(const_cast<TagLib::ID3v2::Tag *>(tag),
@@ -266,7 +251,7 @@ using cg_image_source_unique_ptr = std::unique_ptr<CGImageSource, cf_type_ref_de
 
     // If nothing found check for RVA2 frame
     if (!foundReplayGain) {
-        frameList = tag->frameListMap()["RVA2"];
+        auto frameList = tag->frameListMap()["RVA2"];
 
         for (auto *frameIterator : tag->frameListMap()["RVA2"]) {
             TagLib::ID3v2::RelativeVolumeFrame *relativeVolume =
@@ -284,9 +269,7 @@ using cg_image_source_unique_ptr = std::unique_ptr<CGImageSource, cf_type_ref_de
                 channelType = channels.front();
             }
 
-            float volumeAdjustment = relativeVolume->volumeAdjustment(channelType);
-
-            if (volumeAdjustment != 0.F) {
+            if (float volumeAdjustment = relativeVolume->volumeAdjustment(channelType); volumeAdjustment != 0.f) {
                 if (TagLib::String("track", TagLib::String::Latin1) == relativeVolume->identification()) {
                     self.replayGainTrackGain = @(volumeAdjustment);
                 } else if (TagLib::String("album", TagLib::String::Latin1) == relativeVolume->identification()) {
@@ -321,8 +304,8 @@ using cg_image_source_unique_ptr = std::unique_ptr<CGImageSource, cf_type_ref_de
 @end
 
 void sfb::setID3v2TagFromMetadata(SFBAudioMetadata *metadata, TagLib::ID3v2::Tag *tag, bool setAlbumArt) {
-    NSCParameterAssert(metadata != nil);
-    assert(nullptr != tag);
+    assert(metadata != nil);
+    assert(tag != nullptr);
 
     // Use UTF-8 as the default encoding
     (TagLib::ID3v2::FrameFactory::instance())->setDefaultTextEncoding(TagLib::String::UTF8);
@@ -388,7 +371,7 @@ void sfb::setID3v2TagFromMetadata(SFBAudioMetadata *metadata, TagLib::ID3v2::Tag
 
     // BPM
     tag->removeFrames("TBPM");
-    if (metadata.bpm != nil) {
+    if (metadata.bpm) {
         auto *frame = new TagLib::ID3v2::TextIdentificationFrame("TBPM", TagLib::String::Latin1);
         frame->setText(TagLib::StringFromNSString(metadata.bpm.stringValue));
         tag->addFrame(frame);
@@ -396,7 +379,7 @@ void sfb::setID3v2TagFromMetadata(SFBAudioMetadata *metadata, TagLib::ID3v2::Tag
 
     // Rating
     tag->removeFrames("POPM");
-    if (metadata.rating != nil) {
+    if (metadata.rating) {
         TagLib::ID3v2::PopularimeterFrame *frame = new TagLib::ID3v2::PopularimeterFrame();
         frame->setRating(metadata.rating.intValue);
         tag->addFrame(frame);
@@ -409,11 +392,11 @@ void sfb::setID3v2TagFromMetadata(SFBAudioMetadata *metadata, TagLib::ID3v2::Tag
         frame->setText(TagLib::StringFromNSString(
               [NSString stringWithFormat:@"%@/%@", metadata.trackNumber, metadata.trackTotal]));
         tag->addFrame(frame);
-    } else if (metadata.trackNumber != nil) {
+    } else if (metadata.trackNumber) {
         auto *frame = new TagLib::ID3v2::TextIdentificationFrame("TRCK", TagLib::String::Latin1);
         frame->setText(TagLib::StringFromNSString([NSString stringWithFormat:@"%@", metadata.trackNumber]));
         tag->addFrame(frame);
-    } else if (metadata.trackTotal != nil) {
+    } else if (metadata.trackTotal) {
         auto *frame = new TagLib::ID3v2::TextIdentificationFrame("TRCK", TagLib::String::Latin1);
         frame->setText(TagLib::StringFromNSString([NSString stringWithFormat:@"/%@", metadata.trackTotal]));
         tag->addFrame(frame);
@@ -422,7 +405,7 @@ void sfb::setID3v2TagFromMetadata(SFBAudioMetadata *metadata, TagLib::ID3v2::Tag
     // Compilation
     // iTunes uses the TCMP frame for this, which isn't in the standard, but we'll use it for compatibility
     tag->removeFrames("TCMP");
-    if (metadata.compilation != nil) {
+    if (metadata.compilation) {
         auto *frame = new TagLib::ID3v2::TextIdentificationFrame("TCMP", TagLib::String::Latin1);
         frame->setText(metadata.compilation.boolValue ? "1" : "0");
         tag->addFrame(frame);
@@ -435,11 +418,11 @@ void sfb::setID3v2TagFromMetadata(SFBAudioMetadata *metadata, TagLib::ID3v2::Tag
         frame->setText(TagLib::StringFromNSString(
               [NSString stringWithFormat:@"%@/%@", metadata.discNumber, metadata.discTotal]));
         tag->addFrame(frame);
-    } else if (metadata.discNumber != nil) {
+    } else if (metadata.discNumber) {
         auto *frame = new TagLib::ID3v2::TextIdentificationFrame("TPOS", TagLib::String::Latin1);
         frame->setText(TagLib::StringFromNSString([NSString stringWithFormat:@"%@", metadata.discNumber]));
         tag->addFrame(frame);
-    } else if (metadata.discTotal != nil) {
+    } else if (metadata.discTotal) {
         auto *frame = new TagLib::ID3v2::TextIdentificationFrame("TPOS", TagLib::String::Latin1);
         frame->setText(TagLib::StringFromNSString([NSString stringWithFormat:@"/%@", metadata.discTotal]));
         tag->addFrame(frame);
@@ -462,7 +445,7 @@ void sfb::setID3v2TagFromMetadata(SFBAudioMetadata *metadata, TagLib::ID3v2::Tag
 
     // MusicBrainz
     auto *musicBrainzReleaseIDFrame = TagLib::ID3v2::UserTextIdentificationFrame::find(tag, "MusicBrainz Album Id");
-    if (nullptr != musicBrainzReleaseIDFrame) {
+    if (musicBrainzReleaseIDFrame) {
         tag->removeFrame(musicBrainzReleaseIDFrame);
     }
 
@@ -474,7 +457,7 @@ void sfb::setID3v2TagFromMetadata(SFBAudioMetadata *metadata, TagLib::ID3v2::Tag
     }
 
     auto *musicBrainzRecordingIDFrame = TagLib::ID3v2::UserTextIdentificationFrame::find(tag, "MusicBrainz Track Id");
-    if (nullptr != musicBrainzRecordingIDFrame) {
+    if (musicBrainzRecordingIDFrame) {
         tag->removeFrame(musicBrainzRecordingIDFrame);
     }
 
@@ -536,23 +519,23 @@ void sfb::setID3v2TagFromMetadata(SFBAudioMetadata *metadata, TagLib::ID3v2::Tag
     auto *albumGainFrame = TagLib::ID3v2::UserTextIdentificationFrame::find(tag, "replaygain_album_gain");
     auto *albumPeakFrame = TagLib::ID3v2::UserTextIdentificationFrame::find(tag, "replaygain_album_peak");
 
-    if (nullptr != trackGainFrame) {
+    if (trackGainFrame) {
         tag->removeFrame(trackGainFrame);
     }
 
-    if (nullptr != trackPeakFrame) {
+    if (trackPeakFrame) {
         tag->removeFrame(trackPeakFrame);
     }
 
-    if (nullptr != albumGainFrame) {
+    if (albumGainFrame) {
         tag->removeFrame(albumGainFrame);
     }
 
-    if (nullptr != albumPeakFrame) {
+    if (albumPeakFrame) {
         tag->removeFrame(albumPeakFrame);
     }
 
-    if (metadata.replayGainTrackGain != nil) {
+    if (metadata.replayGainTrackGain) {
         auto *frame = new TagLib::ID3v2::UserTextIdentificationFrame();
         frame->setDescription("replaygain_track_gain");
         frame->setText(TagLib::StringFromNSString(
@@ -560,7 +543,7 @@ void sfb::setID3v2TagFromMetadata(SFBAudioMetadata *metadata, TagLib::ID3v2::Tag
         tag->addFrame(frame);
     }
 
-    if (metadata.replayGainTrackPeak != nil) {
+    if (metadata.replayGainTrackPeak) {
         auto *frame = new TagLib::ID3v2::UserTextIdentificationFrame();
         frame->setDescription("replaygain_track_peak");
         frame->setText(TagLib::StringFromNSString(
@@ -568,7 +551,7 @@ void sfb::setID3v2TagFromMetadata(SFBAudioMetadata *metadata, TagLib::ID3v2::Tag
         tag->addFrame(frame);
     }
 
-    if (metadata.replayGainAlbumGain != nil) {
+    if (metadata.replayGainAlbumGain) {
         auto *frame = new TagLib::ID3v2::UserTextIdentificationFrame();
         frame->setDescription("replaygain_album_gain");
         frame->setText(TagLib::StringFromNSString(
@@ -576,7 +559,7 @@ void sfb::setID3v2TagFromMetadata(SFBAudioMetadata *metadata, TagLib::ID3v2::Tag
         tag->addFrame(frame);
     }
 
-    if (metadata.replayGainAlbumPeak != nil) {
+    if (metadata.replayGainAlbumPeak) {
         auto *frame = new TagLib::ID3v2::UserTextIdentificationFrame();
         frame->setDescription("replaygain_album_peak");
         frame->setText(TagLib::StringFromNSString(
@@ -586,7 +569,7 @@ void sfb::setID3v2TagFromMetadata(SFBAudioMetadata *metadata, TagLib::ID3v2::Tag
 
     // Also write the RVA2 frames
     tag->removeFrames("RVA2");
-    if (metadata.replayGainTrackGain != nil) {
+    if (metadata.replayGainTrackGain) {
         auto *relativeVolume = new TagLib::ID3v2::RelativeVolumeFrame();
         relativeVolume->setIdentification(TagLib::String("track", TagLib::String::Latin1));
         relativeVolume->setVolumeAdjustment(metadata.replayGainTrackGain.floatValue,
@@ -594,7 +577,7 @@ void sfb::setID3v2TagFromMetadata(SFBAudioMetadata *metadata, TagLib::ID3v2::Tag
         tag->addFrame(relativeVolume);
     }
 
-    if (metadata.replayGainAlbumGain != nil) {
+    if (metadata.replayGainAlbumGain) {
         auto *relativeVolume = new TagLib::ID3v2::RelativeVolumeFrame();
         relativeVolume->setIdentification(TagLib::String("album", TagLib::String::Latin1));
         relativeVolume->setVolumeAdjustment(metadata.replayGainAlbumGain.floatValue,

--- a/Sources/CSFBAudioEngine/Metadata/SFBAudioMetadata+TagLibMP4Tag.mm
+++ b/Sources/CSFBAudioEngine/Metadata/SFBAudioMetadata+TagLibMP4Tag.mm
@@ -49,21 +49,21 @@ using cg_image_source_unique_ptr = std::unique_ptr<CGImageSource, cf_type_ref_de
     }
 
     if (tag->contains("trkn")) {
-        auto track = tag->item("trkn").toIntPair();
-        if (track.first) {
-            self.trackNumber = @(track.first);
+        auto [trackNumber, trackTotal] = tag->item("trkn").toIntPair();
+        if (trackNumber != 0) {
+            self.trackNumber = @(trackNumber);
         }
-        if (track.second) {
-            self.trackTotal = @(track.second);
+        if (trackTotal != 0) {
+            self.trackTotal = @(trackTotal);
         }
     }
     if (tag->contains("disk")) {
-        auto disc = tag->item("disk").toIntPair();
-        if (disc.first) {
-            self.discNumber = @(disc.first);
+        auto [discNumber, discTotal] = tag->item("disk").toIntPair();
+        if (discNumber != 0) {
+            self.discNumber = @(discNumber);
         }
-        if (disc.second) {
-            self.discTotal = @(disc.second);
+        if (discTotal != 0) {
+            self.discTotal = @(discTotal);
         }
     }
     if (tag->contains("cpil")) {
@@ -72,8 +72,7 @@ using cg_image_source_unique_ptr = std::unique_ptr<CGImageSource, cf_type_ref_de
         }
     }
     if (tag->contains("tmpo")) {
-        auto bpm = tag->item("tmpo").toInt();
-        if (bpm) {
+        if (auto bpm = tag->item("tmpo").toInt(); bpm != 0) {
             self.bpm = @(bpm);
         }
     }
@@ -180,8 +179,8 @@ using cg_image_source_unique_ptr = std::unique_ptr<CGImageSource, cf_type_ref_de
 namespace {
 
 void SetMP4Item(TagLib::MP4::Tag *tag, const char *key, NSString *value) {
-    assert(nullptr != tag);
-    assert(nullptr != key);
+    assert(tag != nullptr);
+    assert(key != nullptr);
 
     // Remove the existing item with this name
     tag->removeItem(key);
@@ -192,20 +191,20 @@ void SetMP4Item(TagLib::MP4::Tag *tag, const char *key, NSString *value) {
 }
 
 void SetMP4ItemInt(TagLib::MP4::Tag *tag, const char *key, NSNumber *value) {
-    assert(nullptr != tag);
-    assert(nullptr != key);
+    assert(tag != nullptr);
+    assert(key != nullptr);
 
     // Remove the existing item with this name
     tag->removeItem(key);
 
-    if (value != nil) {
+    if (value) {
         tag->setItem(key, TagLib::MP4::Item(value.intValue));
     }
 }
 
 void SetMP4ItemIntPair(TagLib::MP4::Tag *tag, const char *key, NSNumber *valueOne, NSNumber *valueTwo) {
-    assert(nullptr != tag);
-    assert(nullptr != key);
+    assert(tag != nullptr);
+    assert(key != nullptr);
 
     // Remove the existing item with this name
     tag->removeItem(key);
@@ -216,10 +215,10 @@ void SetMP4ItemIntPair(TagLib::MP4::Tag *tag, const char *key, NSNumber *valueOn
 }
 
 void SetMP4ItemBoolean(TagLib::MP4::Tag *tag, const char *key, NSNumber *value) {
-    assert(nullptr != tag);
-    assert(nullptr != key);
+    assert(tag != nullptr);
+    assert(key != nullptr);
 
-    if (value == nil) {
+    if (!value) {
         tag->removeItem(key);
     } else {
         tag->setItem(key, TagLib::MP4::Item(value.boolValue ? 1 : 0));
@@ -227,17 +226,25 @@ void SetMP4ItemBoolean(TagLib::MP4::Tag *tag, const char *key, NSNumber *value) 
 }
 
 void SetMP4ItemDoubleWithFormat(TagLib::MP4::Tag *tag, const char *key, NSNumber *value, NSString *format = nil) {
-    assert(nullptr != tag);
-    assert(nullptr != key);
+    assert(tag != nullptr);
+    assert(key != nullptr);
 
-    SetMP4Item(tag, key, value != nil ? [NSString stringWithFormat:(format ?: @"%f"), value.doubleValue] : nil);
+    if (!value) {
+        SetMP4Item(tag, key, nil);
+    } else {
+        if (!format) {
+            SetMP4Item(tag, key, [NSString stringWithFormat:@"%f", value.doubleValue]);
+        } else {
+            SetMP4Item(tag, key, [NSString stringWithFormat:format, value.doubleValue]);
+        }
+    }
 }
 
 } /* namespace */
 
 void sfb::setMP4TagFromMetadata(SFBAudioMetadata *metadata, TagLib::MP4::Tag *tag, bool setAlbumArt) {
-    NSCParameterAssert(metadata != nil);
-    assert(nullptr != tag);
+    assert(metadata != nil);
+    assert(tag != nullptr);
 
     SetMP4Item(tag, "\251nam", metadata.title);
     SetMP4Item(tag, "\251ART", metadata.artist);

--- a/Sources/CSFBAudioEngine/Metadata/SFBAudioMetadata+TagLibTag.mm
+++ b/Sources/CSFBAudioEngine/Metadata/SFBAudioMetadata+TagLibTag.mm
@@ -17,11 +17,11 @@
     self.artist = [NSString stringWithUTF8String:tag->artist().toCString(true)];
     self.genre = [NSString stringWithUTF8String:tag->genre().toCString(true)];
 
-    if (tag->year()) {
+    if (tag->year() != 0) {
         self.releaseDate = @(tag->year()).stringValue;
     }
 
-    if (tag->track()) {
+    if (tag->track() != 0) {
         self.trackNumber = @(tag->track());
     }
 
@@ -31,14 +31,14 @@
 @end
 
 void sfb::setTagFromMetadata(SFBAudioMetadata *metadata, TagLib::Tag *tag) {
-    NSCParameterAssert(metadata != nil);
-    assert(nullptr != tag);
+    assert(metadata != nil);
+    assert(tag != nullptr);
 
     tag->setTitle(TagLib::StringFromNSString(metadata.title));
     tag->setArtist(TagLib::StringFromNSString(metadata.artist));
     tag->setAlbum(TagLib::StringFromNSString(metadata.albumTitle));
     tag->setComment(TagLib::StringFromNSString(metadata.comment));
     tag->setGenre(TagLib::StringFromNSString(metadata.genre));
-    tag->setYear(metadata.releaseDate ? (unsigned int)metadata.releaseDate.intValue : 0);
+    tag->setYear(metadata.releaseDate ? static_cast<unsigned int>(metadata.releaseDate.intValue) : 0);
     tag->setTrack(metadata.trackNumber.unsignedIntValue);
 }

--- a/Sources/CSFBAudioEngine/Metadata/SFBAudioMetadata+TagLibXiphComment.mm
+++ b/Sources/CSFBAudioEngine/Metadata/SFBAudioMetadata+TagLibXiphComment.mm
@@ -111,7 +111,7 @@ using cg_image_source_unique_ptr = std::unique_ptr<CGImageSource, cf_type_ref_de
         }
     }
 
-    if (additionalMetadata.count) {
+    if (additionalMetadata.count > 0) {
         self.additionalMetadata = additionalMetadata;
     }
 
@@ -136,8 +136,8 @@ using cg_image_source_unique_ptr = std::unique_ptr<CGImageSource, cf_type_ref_de
 namespace {
 
 void SetXiphComment(TagLib::Ogg::XiphComment *tag, const char *key, NSString *value) {
-    assert(nullptr != tag);
-    assert(nullptr != key);
+    assert(tag != nullptr);
+    assert(key != nullptr);
 
     // Remove the existing comment with this name
     tag->removeFields(key);
@@ -148,17 +148,17 @@ void SetXiphComment(TagLib::Ogg::XiphComment *tag, const char *key, NSString *va
 }
 
 void SetXiphCommentNumber(TagLib::Ogg::XiphComment *tag, const char *key, NSNumber *value) {
-    assert(nullptr != tag);
-    assert(nullptr != key);
+    assert(tag != nullptr);
+    assert(key != nullptr);
 
     SetXiphComment(tag, key, value.stringValue);
 }
 
 void SetXiphCommentBoolean(TagLib::Ogg::XiphComment *tag, const char *key, NSNumber *value) {
-    assert(nullptr != tag);
-    assert(nullptr != key);
+    assert(tag != nullptr);
+    assert(key != nullptr);
 
-    if (value == nil) {
+    if (!value) {
         SetXiphComment(tag, key, nil);
     } else {
         SetXiphComment(tag, key, value.boolValue ? @"1" : @"0");
@@ -167,17 +167,25 @@ void SetXiphCommentBoolean(TagLib::Ogg::XiphComment *tag, const char *key, NSNum
 
 void SetXiphCommentDoubleWithFormat(TagLib::Ogg::XiphComment *tag, const char *key, NSNumber *value,
                                     NSString *format = nil) {
-    assert(nullptr != tag);
-    assert(nullptr != key);
+    assert(tag != nullptr);
+    assert(key != nullptr);
 
-    SetXiphComment(tag, key, value != nil ? [NSString stringWithFormat:(format ?: @"%f"), value.doubleValue] : nil);
+    if (!value) {
+        SetXiphComment(tag, key, nil);
+    } else {
+        if (!format) {
+            SetXiphComment(tag, key, [NSString stringWithFormat:@"%f", value.doubleValue]);
+        } else {
+            SetXiphComment(tag, key, [NSString stringWithFormat:format, value.doubleValue]);
+        }
+    }
 }
 
 } /* namespace */
 
 void sfb::setXiphCommentFromMetadata(SFBAudioMetadata *metadata, TagLib::Ogg::XiphComment *tag, bool setAlbumArt) {
-    NSCParameterAssert(metadata != nil);
-    assert(nullptr != tag);
+    assert(metadata != nil);
+    assert(tag != nullptr);
 
     // Standard tags
     SetXiphComment(tag, "ALBUM", metadata.albumTitle);
@@ -237,7 +245,7 @@ void sfb::setXiphCommentFromMetadata(SFBAudioMetadata *metadata, TagLib::Ogg::Xi
 }
 
 std::unique_ptr<TagLib::FLAC::Picture> sfb::ConvertAttachedPictureToFLACPicture(SFBAttachedPicture *attachedPicture) {
-    NSCParameterAssert(attachedPicture != nil);
+    assert(attachedPicture != nil);
 
     cg_image_source_unique_ptr imageSource{
           CGImageSourceCreateWithData((__bridge CFDataRef)attachedPicture.imageData, nullptr)};

--- a/Sources/CSFBAudioEngine/Metadata/SFBDSDIFFFile.mm
+++ b/Sources/CSFBAudioEngine/Metadata/SFBDSDIFFFile.mm
@@ -97,10 +97,10 @@ SFBAudioFileFormatName const SFBAudioFileFormatNameDSDIFF = @"org.sbooth.AudioEn
             auto *properties = file.audioProperties();
             sfb::addAudioPropertiesToDictionary(properties, propertiesDictionary);
 
-            if (properties->bitsPerSample()) {
+            if (properties->bitsPerSample() != 0) {
                 propertiesDictionary[SFBAudioPropertiesKeyBitDepth] = @(properties->bitsPerSample());
             }
-            if (properties->sampleCount()) {
+            if (properties->sampleCount() != 0) {
                 propertiesDictionary[SFBAudioPropertiesKeyFrameLength] = @(properties->sampleCount());
             }
         }

--- a/Sources/CSFBAudioEngine/Metadata/SFBDSFFile.mm
+++ b/Sources/CSFBAudioEngine/Metadata/SFBDSFFile.mm
@@ -96,10 +96,10 @@ SFBAudioFileFormatName const SFBAudioFileFormatNameDSF = @"org.sbooth.AudioEngin
             auto *properties = file.audioProperties();
             sfb::addAudioPropertiesToDictionary(properties, propertiesDictionary);
 
-            if (properties->bitsPerSample()) {
+            if (properties->bitsPerSample() != 0) {
                 propertiesDictionary[SFBAudioPropertiesKeyBitDepth] = @(properties->bitsPerSample());
             }
-            if (properties->sampleCount()) {
+            if (properties->sampleCount() != 0) {
                 propertiesDictionary[SFBAudioPropertiesKeyFrameLength] = @(properties->sampleCount());
             }
         }

--- a/Sources/CSFBAudioEngine/Metadata/SFBFLACFile.mm
+++ b/Sources/CSFBAudioEngine/Metadata/SFBFLACFile.mm
@@ -99,10 +99,10 @@ SFBAudioFileFormatName const SFBAudioFileFormatNameFLAC = @"org.sbooth.AudioEngi
             auto *properties = file.audioProperties();
             sfb::addAudioPropertiesToDictionary(properties, propertiesDictionary);
 
-            if (properties->bitsPerSample()) {
+            if (properties->bitsPerSample() != 0) {
                 propertiesDictionary[SFBAudioPropertiesKeyBitDepth] = @(properties->bitsPerSample());
             }
-            if (properties->sampleFrames()) {
+            if (properties->sampleFrames() != 0) {
                 propertiesDictionary[SFBAudioPropertiesKeyFrameLength] = @(properties->sampleFrames());
             }
         }

--- a/Sources/CSFBAudioEngine/Metadata/SFBMP3File.mm
+++ b/Sources/CSFBAudioEngine/Metadata/SFBMP3File.mm
@@ -128,7 +128,7 @@ SFBAudioFileFormatName const SFBAudioFileFormatNameMP3 = @"org.sbooth.AudioEngin
             }
 #endif
 
-            if (properties->xingHeader() && properties->xingHeader()->totalFrames()) {
+            if (properties->xingHeader() && properties->xingHeader()->totalFrames() != 0) {
                 propertiesDictionary[SFBAudioPropertiesKeyFrameLength] = @(properties->xingHeader()->totalFrames());
             }
         }

--- a/Sources/CSFBAudioEngine/Metadata/SFBMP4File.mm
+++ b/Sources/CSFBAudioEngine/Metadata/SFBMP4File.mm
@@ -96,7 +96,7 @@ SFBAudioFileFormatName const SFBAudioFileFormatNameMP4 = @"org.sbooth.AudioEngin
             auto *properties = file.audioProperties();
             sfb::addAudioPropertiesToDictionary(properties, propertiesDictionary);
 
-            if (properties->bitsPerSample()) {
+            if (properties->bitsPerSample() != 0) {
                 propertiesDictionary[SFBAudioPropertiesKeyBitDepth] = @(properties->bitsPerSample());
             }
             switch (properties->codec()) {

--- a/Sources/CSFBAudioEngine/Metadata/SFBMonkeysAudioFile.mm
+++ b/Sources/CSFBAudioEngine/Metadata/SFBMonkeysAudioFile.mm
@@ -97,10 +97,10 @@ SFBAudioFileFormatName const SFBAudioFileFormatNameMonkeysAudio = @"org.sbooth.A
             auto *properties = file.audioProperties();
             sfb::addAudioPropertiesToDictionary(properties, propertiesDictionary);
 
-            if (properties->bitsPerSample()) {
+            if (properties->bitsPerSample() != 0) {
                 propertiesDictionary[SFBAudioPropertiesKeyBitDepth] = @(properties->bitsPerSample());
             }
-            if (properties->sampleFrames()) {
+            if (properties->sampleFrames() != 0) {
                 propertiesDictionary[SFBAudioPropertiesKeyFrameLength] = @(properties->sampleFrames());
             }
         }

--- a/Sources/CSFBAudioEngine/Metadata/SFBMusepackFile.mm
+++ b/Sources/CSFBAudioEngine/Metadata/SFBMusepackFile.mm
@@ -97,7 +97,7 @@ SFBAudioFileFormatName const SFBAudioFileFormatNameMusepack = @"org.sbooth.Audio
             auto *properties = file.audioProperties();
             sfb::addAudioPropertiesToDictionary(properties, propertiesDictionary);
 
-            if (properties->sampleFrames()) {
+            if (properties->sampleFrames() != 0) {
                 propertiesDictionary[SFBAudioPropertiesKeyFrameLength] = @(properties->sampleFrames());
             }
         }

--- a/Sources/CSFBAudioEngine/Metadata/SFBOggFLACFile.mm
+++ b/Sources/CSFBAudioEngine/Metadata/SFBOggFLACFile.mm
@@ -96,7 +96,7 @@ SFBAudioFileFormatName const SFBAudioFileFormatNameOggFLAC = @"org.sbooth.AudioE
             auto *properties = file.audioProperties();
             sfb::addAudioPropertiesToDictionary(properties, propertiesDictionary);
 
-            if (properties->bitsPerSample()) {
+            if (properties->bitsPerSample() != 0) {
                 propertiesDictionary[SFBAudioPropertiesKeyBitDepth] = @(properties->bitsPerSample());
             }
         }

--- a/Sources/CSFBAudioEngine/Metadata/SFBTrueAudioFile.mm
+++ b/Sources/CSFBAudioEngine/Metadata/SFBTrueAudioFile.mm
@@ -97,10 +97,10 @@ SFBAudioFileFormatName const SFBAudioFileFormatNameTrueAudio = @"org.sbooth.Audi
             auto *properties = file.audioProperties();
             sfb::addAudioPropertiesToDictionary(properties, propertiesDictionary);
 
-            if (properties->bitsPerSample()) {
+            if (properties->bitsPerSample() != 0) {
                 propertiesDictionary[SFBAudioPropertiesKeyBitDepth] = @(properties->bitsPerSample());
             }
-            if (properties->sampleFrames()) {
+            if (properties->sampleFrames() != 0) {
                 propertiesDictionary[SFBAudioPropertiesKeyFrameLength] = @(properties->sampleFrames());
             }
         }

--- a/Sources/CSFBAudioEngine/Metadata/SFBWAVEFile.mm
+++ b/Sources/CSFBAudioEngine/Metadata/SFBWAVEFile.mm
@@ -97,10 +97,10 @@ SFBAudioFileFormatName const SFBAudioFileFormatNameWAVE = @"org.sbooth.AudioEngi
             auto *properties = file.audioProperties();
             sfb::addAudioPropertiesToDictionary(properties, propertiesDictionary);
 
-            if (properties->bitsPerSample()) {
+            if (properties->bitsPerSample() != 0) {
                 propertiesDictionary[SFBAudioPropertiesKeyBitDepth] = @(properties->bitsPerSample());
             }
-            if (properties->sampleFrames()) {
+            if (properties->sampleFrames() != 0) {
                 propertiesDictionary[SFBAudioPropertiesKeyFrameLength] = @(properties->sampleFrames());
             }
         }

--- a/Sources/CSFBAudioEngine/Metadata/SFBWavPackFile.mm
+++ b/Sources/CSFBAudioEngine/Metadata/SFBWavPackFile.mm
@@ -97,10 +97,10 @@ SFBAudioFileFormatName const SFBAudioFileFormatNameWavPack = @"org.sbooth.AudioE
             auto *properties = file.audioProperties();
             sfb::addAudioPropertiesToDictionary(properties, propertiesDictionary);
 
-            if (properties->bitsPerSample()) {
+            if (properties->bitsPerSample() != 0) {
                 propertiesDictionary[SFBAudioPropertiesKeyBitDepth] = @(properties->bitsPerSample());
             }
-            if (properties->sampleFrames()) {
+            if (properties->sampleFrames() != 0) {
                 propertiesDictionary[SFBAudioPropertiesKeyFrameLength] = @(properties->sampleFrames());
             }
         }

--- a/Sources/CSFBAudioEngine/Player/AudioPlayer.h
+++ b/Sources/CSFBAudioEngine/Player/AudioPlayer.h
@@ -194,13 +194,13 @@ class AudioPlayer final {
     /// Possible bits in `flags_`
     enum class Flags : unsigned int {
         /// Cached value of `engine_.isRunning`
-        engineIsRunning = 1U << 0,
+        engineIsRunning = 1u << 0,
         /// The render block should output audio
-        isPlaying = 1U << 1,
+        isPlaying = 1u << 1,
         /// The render block should output silence
-        isMuted = 1U << 2,
+        isMuted = 1u << 2,
         /// The ring buffer needs to be drained during the next render cycle
-        drainRequired = 1U << 3,
+        drainRequired = 1u << 3,
     };
 
     // MARK: - Decoding
@@ -341,7 +341,7 @@ inline bool AudioPlayer::isPaused() const noexcept {
 
 inline bool AudioPlayer::isStopped() const noexcept {
     const auto flags = flags_.load(std::memory_order_acquire);
-    return !(flags & static_cast<unsigned int>(Flags::engineIsRunning));
+    return (flags & static_cast<unsigned int>(Flags::engineIsRunning)) == 0;
 }
 
 inline bool AudioPlayer::isReady() const noexcept {


### PR DESCRIPTION
## Pull request overview

This PR performs miscellaneous code cleanup across the CSFBAudioEngine codebase, focusing on style consistency and code clarity improvements without changing functionality.

**Changes:**
- Standardized literal suffixes (1U → 1u, F → f) and made bitwise flag comparisons explicit
- Modernized C++ code with structured bindings and if-init statements  
- Unified nullptr/nil comparison patterns and expanded nested ternary operators for readability