### PR TITLE
Fix warnings about `Equatable` conformance

### DIFF
--- a/Sources/SFBAudioEngine/SFBPlaybackPosition.swift
+++ b/Sources/SFBAudioEngine/SFBPlaybackPosition.swift
@@ -46,7 +46,7 @@ extension PlaybackPosition {
     }
 }
 
-extension PlaybackPosition: Equatable {
+extension PlaybackPosition: @retroactive Equatable {
     public static func == (lhs: PlaybackPosition, rhs: PlaybackPosition) -> Bool {
         lhs.framePosition == rhs.framePosition && lhs.frameLength == rhs.frameLength
     }

--- a/Sources/SFBAudioEngine/SFBPlaybackPosition.swift
+++ b/Sources/SFBAudioEngine/SFBPlaybackPosition.swift
@@ -46,7 +46,7 @@ extension PlaybackPosition {
     }
 }
 
-extension PlaybackPosition: @retroactive Equatable {
+extension CSFBAudioEngine.PlaybackPosition: Swift.Equatable {
     public static func == (lhs: PlaybackPosition, rhs: PlaybackPosition) -> Bool {
         lhs.framePosition == rhs.framePosition && lhs.frameLength == rhs.frameLength
     }

--- a/Sources/SFBAudioEngine/SFBPlaybackPosition.swift
+++ b/Sources/SFBAudioEngine/SFBPlaybackPosition.swift
@@ -46,7 +46,7 @@ extension PlaybackPosition {
     }
 }
 
-extension SFBAudioEngine.PlaybackPosition: Swift.Equatable {
+extension CSFBAudioEngine.PlaybackPosition: Swift.Equatable {
     public static func == (lhs: PlaybackPosition, rhs: PlaybackPosition) -> Bool {
         lhs.framePosition == rhs.framePosition && lhs.frameLength == rhs.frameLength
     }

--- a/Sources/SFBAudioEngine/SFBPlaybackPosition.swift
+++ b/Sources/SFBAudioEngine/SFBPlaybackPosition.swift
@@ -46,7 +46,7 @@ extension PlaybackPosition {
     }
 }
 
-extension CSFBAudioEngine.PlaybackPosition: Swift.Equatable {
+extension SFBAudioEngine.PlaybackPosition: Swift.Equatable {
     public static func == (lhs: PlaybackPosition, rhs: PlaybackPosition) -> Bool {
         lhs.framePosition == rhs.framePosition && lhs.frameLength == rhs.frameLength
     }

--- a/Sources/SFBAudioEngine/SFBPlaybackTime.swift
+++ b/Sources/SFBAudioEngine/SFBPlaybackTime.swift
@@ -46,7 +46,7 @@ extension PlaybackTime {
     }
 }
 
-extension PlaybackTime: Equatable {
+extension PlaybackTime: @retroactive Equatable {
     public static func == (lhs: PlaybackTime, rhs: PlaybackTime) -> Bool {
         lhs.currentTime == rhs.currentTime && lhs.totalTime == rhs.totalTime
     }

--- a/Sources/SFBAudioEngine/SFBPlaybackTime.swift
+++ b/Sources/SFBAudioEngine/SFBPlaybackTime.swift
@@ -46,7 +46,7 @@ extension PlaybackTime {
     }
 }
 
-extension SFBAudioEngine.PlaybackTime: Swift.Equatable {
+extension CSFBAudioEngine.PlaybackTime: Swift.Equatable {
     public static func == (lhs: PlaybackTime, rhs: PlaybackTime) -> Bool {
         lhs.currentTime == rhs.currentTime && lhs.totalTime == rhs.totalTime
     }

--- a/Sources/SFBAudioEngine/SFBPlaybackTime.swift
+++ b/Sources/SFBAudioEngine/SFBPlaybackTime.swift
@@ -46,7 +46,7 @@ extension PlaybackTime {
     }
 }
 
-extension CSFBAudioEngine.PlaybackTime: Swift.Equatable {
+extension SFBAudioEngine.PlaybackTime: Swift.Equatable {
     public static func == (lhs: PlaybackTime, rhs: PlaybackTime) -> Bool {
         lhs.currentTime == rhs.currentTime && lhs.totalTime == rhs.totalTime
     }

--- a/Sources/SFBAudioEngine/SFBPlaybackTime.swift
+++ b/Sources/SFBAudioEngine/SFBPlaybackTime.swift
@@ -46,7 +46,7 @@ extension PlaybackTime {
     }
 }
 
-extension PlaybackTime: @retroactive Equatable {
+extension CSFBAudioEngine.PlaybackTime: Swift.Equatable {
     public static func == (lhs: PlaybackTime, rhs: PlaybackTime) -> Bool {
         lhs.currentTime == rhs.currentTime && lhs.totalTime == rhs.totalTime
     }


### PR DESCRIPTION
By using the fully-qualified type names the warning is suppressed without the need for the `retroactive` attribute.