### PR TITLE
Add `audioPlayerShouldStopAtEndOfAudio:` delegate method

### DIFF
--- a/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
+++ b/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
@@ -2101,8 +2101,8 @@ void sfb::AudioPlayer::handleRenderingWillCompleteEvent(Decoder decoder, uint64_
             that->setNowPlaying(nil);
             auto shouldStop = true;
 
-            if ([player.delegate respondsToSelector:@selector(audioPlayerEndOfAudio:)]) {
-                shouldStop = [player.delegate audioPlayerEndOfAudio:player];
+            if ([player.delegate respondsToSelector:@selector(audioPlayerShouldStopAtEndOfAudio:)]) {
+                shouldStop = [player.delegate audioPlayerShouldStopAtEndOfAudio:player];
             }
 
             if (shouldStop) {

--- a/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
+++ b/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
@@ -2100,9 +2100,13 @@ void sfb::AudioPlayer::handleRenderingWillCompleteEvent(Decoder decoder, uint64_
 
             that->setNowPlaying(nil);
 
+            auto shouldStop = true;
+
             if ([player.delegate respondsToSelector:@selector(audioPlayerEndOfAudio:)]) {
-                [player.delegate audioPlayerEndOfAudio:player];
-            } else {
+                shouldStop = [player.delegate audioPlayerEndOfAudio:player];
+            }
+
+            if (shouldStop) {
                 const auto didStopEngine = stopEngineIfRunning();
                 if (didStopEngine &&
                     [player.delegate respondsToSelector:@selector(audioPlayer:playbackStateChanged:)]) {

--- a/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
+++ b/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
@@ -2099,7 +2099,6 @@ void sfb::AudioPlayer::handleRenderingWillCompleteEvent(Decoder decoder, uint64_
 #endif /* DEBUG */
 
             that->setNowPlaying(nil);
-
             auto shouldStop = true;
 
             if ([player.delegate respondsToSelector:@selector(audioPlayerEndOfAudio:)]) {

--- a/Sources/CSFBAudioEngine/include/SFBAudioEngine/SFBAudioPlayer.h
+++ b/Sources/CSFBAudioEngine/include/SFBAudioEngine/SFBAudioPlayer.h
@@ -364,10 +364,10 @@ NS_SWIFT_NAME(AudioPlayer.Delegate)
 /// - parameter audioPlayer: The `SFBAudioPlayer` object
 /// - parameter playbackState: The current playback state
 - (void)audioPlayer:(SFBAudioPlayer *)audioPlayer playbackStateChanged:(SFBAudioPlayerPlaybackState)playbackState;
-/// Called to notify the delegate when rendering is complete for all available decoders
+/// Called to query the delegate whether playback should stop when rendering is complete for all available decoders
 /// - parameter audioPlayer: The `SFBAudioPlayer` object
 /// - returns: `YES` if the player should stop playback, `NO` to continue rendering silence
-- (BOOL)audioPlayerEndOfAudio:(SFBAudioPlayer *)audioPlayer NS_SWIFT_NAME(audioPlayerEndOfAudio(_:));
+- (BOOL)audioPlayerShouldStopAtEndOfAudio:(SFBAudioPlayer *)audioPlayer NS_SWIFT_NAME(audioPlayerShouldStopAtEndOfAudio(_:));
 /// Called to notify the delegate that the decoding and rendering processes for a decoder have been canceled by a
 /// user-initiated request
 /// - warning: Do not change any properties of `decoder`

--- a/Sources/CSFBAudioEngine/include/SFBAudioEngine/SFBAudioPlayer.h
+++ b/Sources/CSFBAudioEngine/include/SFBAudioEngine/SFBAudioPlayer.h
@@ -366,7 +366,8 @@ NS_SWIFT_NAME(AudioPlayer.Delegate)
 - (void)audioPlayer:(SFBAudioPlayer *)audioPlayer playbackStateChanged:(SFBAudioPlayerPlaybackState)playbackState;
 /// Called to notify the delegate when rendering is complete for all available decoders
 /// - parameter audioPlayer: The `SFBAudioPlayer` object
-- (void)audioPlayerEndOfAudio:(SFBAudioPlayer *)audioPlayer NS_SWIFT_NAME(audioPlayerEndOfAudio(_:));
+/// - returns: `YES` if the player should stop playback, `NO` to continue rendering silence
+- (BOOL)audioPlayerEndOfAudio:(SFBAudioPlayer *)audioPlayer NS_SWIFT_NAME(audioPlayerEndOfAudio(_:));
 /// Called to notify the delegate that the decoding and rendering processes for a decoder have been canceled by a
 /// user-initiated request
 /// - warning: Do not change any properties of `decoder`

--- a/Sources/CSFBAudioEngine/include/SFBAudioEngine/SFBAudioPlayer.h
+++ b/Sources/CSFBAudioEngine/include/SFBAudioEngine/SFBAudioPlayer.h
@@ -367,7 +367,8 @@ NS_SWIFT_NAME(AudioPlayer.Delegate)
 /// Called to query the delegate whether playback should stop when rendering is complete for all available decoders
 /// - parameter audioPlayer: The `SFBAudioPlayer` object
 /// - returns: `YES` if the player should stop playback, `NO` to continue rendering silence
-- (BOOL)audioPlayerShouldStopAtEndOfAudio:(SFBAudioPlayer *)audioPlayer NS_SWIFT_NAME(audioPlayerShouldStopAtEndOfAudio(_:));
+- (BOOL)audioPlayerShouldStopAtEndOfAudio:(SFBAudioPlayer *)audioPlayer
+        NS_SWIFT_NAME(audioPlayerShouldStopAtEndOfAudio(_:));
 /// Called to notify the delegate that the decoding and rendering processes for a decoder have been canceled by a
 /// user-initiated request
 /// - warning: Do not change any properties of `decoder`


### PR DESCRIPTION
This is a breaking API change since this PR removes the `audioPlayerEndOfAudio:` delegate method.