### PR TITLE
Pause engine before reconfiguring graph in configuration-change handler

### DIFF
--- a/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
+++ b/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
@@ -2244,17 +2244,49 @@ void sfb::AudioPlayer::handleAudioEngineConfigurationChange(AVAudioEngine *engin
                          stringDescribingAVAudioFormat(outputNodeOutputFormat));
 #endif /* DEBUG */
 
-            [engine_ disconnectNodeInput:outputNode bus:0];
+            // The "AVAudioEngine stops itself when a configuration change occurs"
+            // assumption above does not hold universally on iOS 26.4.x — the
+            // notification can be delivered while engine_.isRunning is still true.
+            // Disconnecting the output node in that state raises NSException
+            // ("required condition is false: !IsRunning()"), which propagates
+            // through this noexcept C++ frame to std::terminate.
+            //
+            // Defense: pause the engine before reconfiguring, and wrap the AVFAudio
+            // calls in @try/@catch so any future precondition violations bail out
+            // gracefully rather than crashing the host app.
+            @try {
+                if (engine_.isRunning) {
+                    [engine_ pause];
+                }
 
-            // Reconnect the mixer and output nodes using the output node's output format
-            [engine_ connect:mixerNode to:outputNode format:outputNodeOutputFormat];
+                [engine_ disconnectNodeInput:outputNode bus:0];
 
-            [engine_ prepare];
+                // Reconnect the mixer and output nodes using the output node's output format
+                [engine_ connect:mixerNode to:outputNode format:outputNodeOutputFormat];
+
+                [engine_ prepare];
+            } @catch (NSException *exception) {
+                os_log_error(log_,
+                             "AVAudioEngine raised NSException during configuration-change graph rebuild: "
+                             "%{public}@. Bailing out; the next play() will rebuild the graph.",
+                             exception);
+                return;
+            }
         }
 
         // Restart AVAudioEngine if previously running
         if (bits::is_set(prevState, Flags::engineIsRunning)) {
-            if (NSError *startError = nil; ![engine_ startAndReturnError:&startError]) {
+            NSError *startError = nil;
+            BOOL started = NO;
+            @try {
+                started = [engine_ startAndReturnError:&startError];
+            } @catch (NSException *exception) {
+                os_log_error(log_,
+                             "AVAudioEngine raised NSException during configuration-change restart: %{public}@",
+                             exception);
+                return;
+            }
+            if (!started) {
                 os_log_error(log_, "Error starting AVAudioEngine: %{public}@", startError);
                 lock.unlock();
                 if (__strong id<SFBAudioPlayerDelegate> delegate = player_.delegate;


### PR DESCRIPTION
_[Hey @sbooth! This is obviously an AI-assisted PR, but I wanted to let you know that I'm Human™ and that I've done my best to validate that this addresses a real (if rare) issue. Thank you for SFBAudioEngine, and I hope this is useful!]_

## Problem

`sfb::AudioPlayer::handleAudioEngineConfigurationChange` (AudioPlayer.mm:2199) assumes:

```cpp
// AVAudioEngine stops itself when a configuration change occurs
```

…and proceeds to clear its internal `Flags::engineIsRunning | Flags::isPlaying` flags on that basis, then calls `[engine_ disconnectNodeInput:outputNode bus:0]` if the output format has changed.

On iOS 26.4.x this assumption does not hold universally. The configuration-change notification can be delivered while `engine_.isRunning` is still `true`. `disconnectNodeInput:` then raises an `NSException`:

```
com.apple.coreaudio.avfaudio: required condition is false: !IsRunning()
```

Because the surrounding C++ method is `noexcept` with no `@try/@catch`, the exception propagates through C++ frames to `CPPExceptionTerminate()` → `std::terminate()` → SIGABRT.

## Crash report

Observed on iPhone 16 / iOS 26.4.2, ARM64, TestFlight build of a downstream app. Stack:

```
[Last Exception Backtrace]
3  AVFAudio   AVAudioEngineGraph::_DisconnectInput          AVAudioEngineGraph.mm:2728  ← NSException raised
4  AVFAudio   -[AVAudioEngine disconnectNodeInput:bus:]     AVAudioEngine.mm:155
5  SFB        sfb::AudioPlayer::handleAudioEngineConfigurationChange  AudioPlayer.mm:2247

[Thread 18 Crashed]
9  SFB        sfb::AudioPlayer::handleAudioEngineConfigurationChange  AudioPlayer.mm:2212  ← std::terminate unwound here
…
14 AVFAudio   IOUnitConfigurationChanged → NSNotificationCenter post  (libdispatch)
```

App had been running ~5.5 hours before the crash, consistent with an audio-session event trigger (interruption, route change, headphone connect/disconnect, CarPlay) rather than a startup condition.

## Fix

Two changes inside the `engineMutex_`-held block:

1. **Pause the engine before reconfiguring.** If `engine_.isRunning` is still `true` when the handler runs, call `[engine_ pause]` before `disconnectNodeInput:`. This addresses the root cause — the documented "engine auto-stops" invariant doesn't hold here.
2. **Wrap the AVFAudio calls in `@try/@catch (NSException *)`.** Defensive belt-and-suspenders against any future precondition that AVFAudio decides to enforce. On catch, log via `os_log_error` and `return`. The next `play()` rebuilds the graph from scratch, so bailout state is recoverable.

The same `@try/@catch` is applied around the subsequent `[engine_ startAndReturnError:&startError]` for symmetry — that call also dispatches into AVFAudio internals that can raise.

## Behavior changes

- **Successful path**: identical, except `engine_.pause` is called first if the engine is unexpectedly still running. `pause` preserves engine state, so the existing `startAndReturnError:` at line 2257 still resumes correctly.
- **Exception path**: previously `std::terminate()`; now logged and the handler bails. The engine's flags have already been cleared (matching the pre-patch state assumption that the engine had stopped). The next `play()` rebuilds the graph.

## Tested

- Builds clean against `main` (`ab6a858`).
- I do not have a deterministic reproducer for the underlying race; the fix is verified by code inspection against the crash log + Sentry-captured exception reason.

## Related

- Companion to #901 (NDEBUG in release builds) and #902 (assertion/runtime-check updates) — same family of "AVFAudio precondition fires in production" issues, addressed at a different call site.