### PR TITLE
Fix FLAC playback auto-stop issues and reset frame buffer on seek

### DIFF
--- a/Sources/CSFBAudioEngine/Decoders/SFBFLACDecoder.mm
+++ b/Sources/CSFBAudioEngine/Decoders/SFBFLACDecoder.mm
@@ -446,6 +446,16 @@ void errorCallback(const FLAC__StreamDecoder *decoder, FLAC__StreamDecoderErrorS
         return YES;
     }
 
+    if (_streamInfo.total_samples > 0) {
+        if (_framePosition >= static_cast<AVAudioFramePosition>(_streamInfo.total_samples)) {
+            return YES;
+        }
+        const auto framesRemaining = _streamInfo.total_samples - static_cast<uint64_t>(_framePosition);
+        if (framesRemaining < frameLength) {
+            frameLength = static_cast<AVAudioFrameCount>(framesRemaining);
+        }
+    }
+
     AVAudioFrameCount framesProcessed = 0;
 
     for (;;) {
@@ -501,6 +511,7 @@ void errorCallback(const FLAC__StreamDecoder *decoder, FLAC__StreamDecoderErrorS
     }
 
     _framePosition = frame;
+    _frameBuffer.frameLength = 0;
     return YES;
 }
 


### PR DESCRIPTION
### Description
This pull request addresses two distinct issues in `SFBFLACDecoder`:
1. **FLAC playback not automatically stopping at the end of stream:**
   For certain FLAC files (e.g., those containing trailing metadata, ID3v2 tags, or padding blocks after the audio frames), the underlying decoder continues to process non-audio blocks via `FLAC__stream_decoder_process_single()` successfully. Because `FLAC__stream_decoder_get_state()` does not yet return `FLAC__STREAM_DECODER_END_OF_STREAM` during these calls, the decode loop in `decodeIntoBuffer:frameLength:error:` can get stuck in a spin or fail to immediately signal EOF (returning a buffer frame length of 0).
   * **Fix:** If `_streamInfo.total_samples` is known, we clamp the requested `frameLength` to the remaining samples. If `_framePosition` is already at or past the total sample count, we return early, signaling EOF.
2. **Stale audio frame buffer after seeking:**
   When `seekToFrame:error:` is called, the internal push-to-pull buffer `_frameBuffer` may still contain leftover decoded frames from the pre-seek position. If these are not cleared, the next `decodeIntoBuffer:` call will read these stale frames first, resulting in brief audio artifacts or incorrect position tracking immediately after a seek.
   * **Fix:** Reset `_frameBuffer.frameLength` to `0` upon a successful seek to ensure the next read pulls fresh data from the seek target.
### Changes
* **`Sources/CSFBAudioEngine/Decoders/SFBFLACDecoder.mm`**:
  * Bound check `_framePosition` against `_streamInfo.total_samples` and clamp `frameLength` in `decodeIntoBuffer:frameLength:error:`.
  * Reset `_frameBuffer.frameLength` to `0` in `seekToFrame:error:`.

This is the test file: [https://drive.google.com/file/d/1Jk7PvfMK9YmMoQaWv29iQbxch0d9dtm8/view?usp=sharing](https://drive.google.com/file/d/1Jk7PvfMK9YmMoQaWv29iQbxch0d9dtm8/view?usp=sharing)
