### PR TITLE
Defer decoder opening and decoder state initialization

### DIFF
--- a/Sources/CSFBAudioEngine/Player/AudioPlayer.h
+++ b/Sources/CSFBAudioEngine/Player/AudioPlayer.h
@@ -209,6 +209,8 @@ class AudioPlayer final {
         isMuted = 1u << 2,
         /// The ring buffer needs to be drained during the next render cycle
         drainRequired = 1u << 3,
+        /// A decoder has been dequeued but not yet added as active
+        decoderDequeued = 1u << 4,
     };
 
     // Enable bitmask operations for `Flags`

--- a/Sources/CSFBAudioEngine/Player/AudioPlayer.h
+++ b/Sources/CSFBAudioEngine/Player/AudioPlayer.h
@@ -209,8 +209,6 @@ class AudioPlayer final {
         isMuted = 1u << 2,
         /// The ring buffer needs to be drained during the next render cycle
         drainRequired = 1u << 3,
-        /// A decoder has been dequeued but not yet added as active
-        decoderDequeued = 1u << 4,
     };
 
     // Enable bitmask operations for `Flags`

--- a/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
+++ b/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
@@ -1955,7 +1955,7 @@ bool sfb::AudioPlayer::processFramesRenderedEvent() noexcept {
         while (iter != activeDecoders_.cend()) {
             const auto flags = (*iter)->loadFlags();
 
-            // Skip unitialized decoders
+            // Skip uninitialized decoders
             if (bits::is_set(flags, DecoderState::Flags::needsInitialization)) {
                 ++iter;
                 continue;

--- a/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
+++ b/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
@@ -204,7 +204,7 @@ struct AudioPlayer::DecoderState final {
     const Decoder decoder_{nil};
 
     /// The sample rate of the audio converter's output format
-    std::atomic<double> sampleRate_{0};
+    double sampleRate_{0};
 
     /// Flags
     std::atomic_uint flags_{0};
@@ -215,7 +215,7 @@ struct AudioPlayer::DecoderState final {
     /// The number of frames rendered
     std::atomic_int64_t framesRendered_{0};
     /// The total number of audio frames
-    std::atomic_int64_t frameLength_{SFBUnknownFrameLength};
+    AVAudioFramePosition frameLength_{SFBUnknownFrameLength};
     /// The requested frame
     std::atomic_int64_t requestedFrame_{SFBUnknownFramePosition};
 
@@ -343,8 +343,10 @@ inline bool AudioPlayer::DecoderState::allocate(AVAudioFrameCount frameCapacity)
         framesRendered_.store(framePosition, std::memory_order_release);
     }
 
-    sampleRate_.store(format.sampleRate, std::memory_order_release);
-    frameLength_.store(decoder_.frameLength, std::memory_order_release);
+    // The sample rate and frame length do not need to be individually atomic because they are written only once
+    // and access is guarded behind the atomic flag `Flags::needsInitialization`
+    sampleRate_ = format.sampleRate;
+    frameLength_ = decoder_.frameLength;
 
     clearFlags(Flags::needsInitialization);
 
@@ -352,7 +354,7 @@ inline bool AudioPlayer::DecoderState::allocate(AVAudioFrameCount frameCapacity)
 }
 
 inline double AudioPlayer::DecoderState::sampleRate() const noexcept {
-    return sampleRate_.load(std::memory_order_acquire);
+    return sampleRate_;
 }
 
 inline AVAudioFramePosition AudioPlayer::DecoderState::framePosition() const noexcept {
@@ -363,7 +365,7 @@ inline AVAudioFramePosition AudioPlayer::DecoderState::framePosition() const noe
 }
 
 inline AVAudioFramePosition AudioPlayer::DecoderState::frameLength() const noexcept {
-    return frameLength_.load(std::memory_order_acquire);
+    return frameLength_;
 }
 
 inline bool AudioPlayer::DecoderState::decodeAudio(AVAudioPCMBuffer *_Nonnull buffer, NSError **error) noexcept {

--- a/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
+++ b/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
@@ -247,7 +247,7 @@ struct AudioPlayer::DecoderState final {
         cancelRequested = 1u << 6,
         /// Decoder canceled
         isCanceled = 1u << 7,
-        /// Decoder not initialized
+        /// Decoder state not initialized
         needsInitialization = 1u << 8,
     };
 

--- a/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
+++ b/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
@@ -26,6 +26,7 @@
 #import <concepts>
 #import <limits>
 #import <ranges>
+#import <stdexcept>
 
 namespace {
 
@@ -204,9 +205,9 @@ struct AudioPlayer::DecoderState final {
     const Decoder decoder_{nil};
 
     /// The sample rate of the audio converter's output format
-    double sampleRate_{0};
+    const double sampleRate_{0};
     /// The total number of audio frames
-    AVAudioFramePosition frameLength_{SFBUnknownFrameLength};
+    const AVAudioFramePosition frameLength_{SFBUnknownFrameLength};
 
     /// Flags
     std::atomic_uint flags_{0};
@@ -270,9 +271,7 @@ struct AudioPlayer::DecoderState final {
         return static_cast<Flags>(flags_.fetch_and(~bits::to_underlying(flags), order));
     }
 
-    DecoderState(Decoder _Nonnull decoder) noexcept;
-
-    bool allocate(AVAudioFrameCount frameCapacity) noexcept;
+    DecoderState(Decoder _Nonnull decoder, AVAudioFrameCount frameCapacity);
 
     AVAudioFramePosition framePosition() const noexcept;
     AVAudioFramePosition frameLength() const noexcept;
@@ -287,27 +286,27 @@ struct AudioPlayer::DecoderState final {
 
 uint64_t AudioPlayer::DecoderState::sequenceCounter_ = 1;
 
-inline AudioPlayer::DecoderState::DecoderState(Decoder _Nonnull decoder) noexcept : decoder_{decoder} {
+inline AudioPlayer::DecoderState::DecoderState(Decoder _Nonnull decoder, AVAudioFrameCount frameCapacity)
+    : decoder_{decoder}, sampleRate_{decoder.processingFormat.sampleRate}, frameLength_{decoder.frameLength} {
 #if DEBUG
     assert(decoder != nil);
+    assert(frameCapacity != 0);
 #endif /* DEBUG */
-}
 
-inline bool AudioPlayer::DecoderState::allocate(AVAudioFrameCount frameCapacity) noexcept {
-#if DEBUG
-    assert(converter_ == nil);
-    assert(decodeBuffer_ == nil);
-#endif /* DEBUG */
+    if (decoder_ == nil) {
+        throw std::invalid_argument("Decoder may not be nil");
+    }
 
     auto format = decoder_.processingFormat;
-#if DEBUG
-    assert(format.streamDescription->mFormatID == kAudioFormatLinearPCM);
-#endif /* DEBUG */
+    if (format == nil || format.streamDescription->mFormatID != kAudioFormatLinearPCM) {
+        throw std::invalid_argument("Decoder processing format must be PCM");
+    }
+
     auto standardEquivalentFormat = format.standardEquivalent;
     if (standardEquivalentFormat == nil) {
         os_log_error(log_, "Error converting %{public}@ to standard equivalent format",
                      stringDescribingAVAudioFormat(format));
-        return false;
+        throw std::runtime_error("Error creating standard equivalent format");
     }
 
     // Convert to deinterleaved native-endian float, preserving the channel count and order
@@ -315,28 +314,25 @@ inline bool AudioPlayer::DecoderState::allocate(AVAudioFrameCount frameCapacity)
     if (converter_ == nil) {
         os_log_error(log_, "Error creating AVAudioConverter converting from %{public}@ to %{public}@",
                      stringDescribingAVAudioFormat(format), stringDescribingAVAudioFormat(standardEquivalentFormat));
-        return false;
+        throw std::runtime_error("Error creating AVAudioConverter");
     }
 
     decodeBuffer_ = [[AVAudioPCMBuffer alloc] initWithPCMFormat:converter_.inputFormat frameCapacity:frameCapacity];
     if (decodeBuffer_ == nil) {
-        return false;
+        os_log_error(log_, "Error allocating AVAudioPCMBuffer");
+        throw std::runtime_error("Error allocating AVAudioPCMBuffer");
     }
 
     const auto framePosition = decoder_.framePosition;
     if (framePosition == SFBUnknownFramePosition) {
-        return false;
+        os_log_error(log_, "Unknown frame position in decoder");
+        throw std::runtime_error("Unknown frame position in decoder");
     }
 
     if (framePosition != 0) {
         framesDecoded_.store(framePosition, std::memory_order_release);
         framesRendered_.store(framePosition, std::memory_order_release);
     }
-
-    frameLength_ = decoder_.frameLength;
-    sampleRate_ = format.sampleRate;
-
-    return true;
 }
 
 inline AVAudioFramePosition AudioPlayer::DecoderState::framePosition() const noexcept {
@@ -1295,59 +1291,47 @@ void sfb::AudioPlayer::processDecoders(std::stop_token stoken) noexcept {
 
         // Dequeue the next decoder if there are no decoders that haven't completed decoding
         if (decoderState == nullptr) {
-            {
-                // Lock both mutexes to ensure a decoder doesn't momentarily "disappear"
-                // when transitioning from queued to active
-                std::scoped_lock lock{queuedDecodersMutex_, activeDecodersMutex_};
-
-                if (!queuedDecoders_.empty()) {
-                    // Remove the first decoder from the decoder queue
-                    auto decoder = queuedDecoders_.front();
-                    queuedDecoders_.pop_front();
-
-                    // Create the decoder state and add it to the list of active decoders
-                    try {
-                        activeDecoders_.push_back(std::make_unique<DecoderState>(decoder));
-#if DEBUG
-                        assert(std::ranges::is_sorted(activeDecoders_, std::ranges::less{},
-                                                      &DecoderState::sequenceNumber_));
-#endif /* DEBUG */
-                        decoderState = activeDecoders_.back().get();
-                    } catch (const std::exception &e) {
-                        os_log_error(log_, "Error creating decoder state for %{public}@: %{public}s", decoder,
-                                     e.what());
-                        submitDecodingErrorEvent([NSError errorWithDomain:SFBAudioPlayerErrorDomain
-                                                                     code:SFBAudioPlayerErrorCodeInternalError
-                                                                 userInfo:nil]);
-                        continue;
-                    }
-                }
+            Decoder decoder = nil;
+            if (std::lock_guard lock{queuedDecodersMutex_}; !queuedDecoders_.empty()) {
+                // Pop the first decoder from the decoder queue
+                decoder = queuedDecoders_.front();
+                queuedDecoders_.pop_front();
+                setFlags(Flags::decoderDequeued);
             }
 
-            if (decoderState != nullptr) {
+            if (decoder != nil) {
                 // Open the decoder if necessary
-                if (NSError *error = nil;
-                    !decoderState->decoder_.isOpen && ![decoderState->decoder_ openReturningError:&error]) {
-                    os_log_error(log_, "Error opening %{public}@: %{public}@", decoderState->decoder_, error);
-                    decoderState->error_ = error;
-                    decoderState->setFlags(DecoderState::Flags::cancelRequested);
+                if (NSError *error = nil; !decoder.isOpen && ![decoder openReturningError:&error]) {
+                    os_log_error(log_, "Error opening %{public}@: %{public}@", decoder, error);
+                    submitDecodingErrorEvent(error);
+                    clearFlags(Flags::decoderDequeued);
                     continue;
                 }
 
-                // Allocate decoder state internals
-                if (!decoderState->allocate(ringBufferChunkSize)) {
-                    os_log_error(log_,
-                                 "Error allocating decoder state data: DecoderStateData::allocate failed with frame "
-                                 "capacity %d",
-                                 ringBufferChunkSize);
-                    decoderState->error_ = [NSError errorWithDomain:SFBAudioPlayerErrorDomain
-                                                               code:SFBAudioPlayerErrorCodeInternalError
-                                                           userInfo:nil];
-                    decoderState->setFlags(DecoderState::Flags::cancelRequested);
+                // Create the decoder state and add it to the list of active decoders
+                try {
+                    auto nextDecoderState = std::make_unique<DecoderState>(decoder, ringBufferChunkSize);
+
+                    std::lock_guard lock{activeDecodersMutex_};
+                    activeDecoders_.push_back(std::move(nextDecoderState));
+                    clearFlags(Flags::decoderDequeued);
+
+#if DEBUG
+                    assert(std::ranges::is_sorted(activeDecoders_, std::ranges::less{},
+                                                  &DecoderState::sequenceNumber_));
+#endif /* DEBUG */
+
+                    decoderState = activeDecoders_.back().get();
+                    os_log_debug(log_, "Dequeued %{public}@", decoderState->decoder_);
+                } catch (const std::exception &e) {
+                    os_log_error(log_, "Error creating decoder state for %{public}@: %{public}s", decoder,
+                                 e.what());
+                    submitDecodingErrorEvent([NSError errorWithDomain:SFBAudioPlayerErrorDomain
+                                                                 code:SFBAudioPlayerErrorCodeInternalError
+                                                             userInfo:nil]);
+                    clearFlags(Flags::decoderDequeued);
                     continue;
                 }
-
-                os_log_debug(log_, "Dequeued %{public}@", decoderState->decoder_);
             }
         }
 
@@ -1820,7 +1804,7 @@ bool sfb::AudioPlayer::processDecoderCanceledEvent() noexcept {
         return queuedDecoders_.empty() && activeDecoders_.empty();
     }();
 
-    if (hasNoDecoders) {
+    if (hasNoDecoders && bits::is_clear(loadFlags(), Flags::decoderDequeued)) {
         setNowPlaying(nil);
 
         const auto didStopEngine = stopEngineIfRunning();
@@ -2133,7 +2117,7 @@ void sfb::AudioPlayer::handleRenderingWillCompleteEvent(Decoder decoder, uint64_
         }();
 
         // End of audio
-        if (hasNoDecoders) {
+        if (hasNoDecoders && bits::is_clear(loadFlags(), Flags::decoderDequeued)) {
 #if DEBUG
             os_log_debug(log_, "End of audio reached");
 #endif /* DEBUG */

--- a/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
+++ b/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
@@ -26,7 +26,6 @@
 #import <concepts>
 #import <limits>
 #import <ranges>
-#import <stdexcept>
 
 namespace {
 

--- a/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
+++ b/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
@@ -366,7 +366,7 @@ inline bool AudioPlayer::DecoderState::allocate(AVAudioFrameCount frameCapacity,
     }
 
     sampleRate_.store(format.sampleRate, std::memory_order_release);
-    frameLength_.store(decoder_.frameLength);
+    frameLength_.store(decoder_.frameLength, std::memory_order_release);
 
     clearFlags(Flags::needsInitialization);
 

--- a/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
+++ b/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
@@ -328,7 +328,8 @@ inline bool AudioPlayer::DecoderState::allocate(AVAudioFrameCount frameCapacity)
 
     decodeBuffer_ = [[AVAudioPCMBuffer alloc] initWithPCMFormat:converter_.inputFormat frameCapacity:frameCapacity];
     if (decodeBuffer_ == nil) {
-        os_log_error(log_, "Error allocating AVAudioPCMBuffer with format %{public}@ and frame capacity %d", stringDescribingAVAudioFormat(converter_.inputFormat), frameCapacity);
+        os_log_error(log_, "Error allocating AVAudioPCMBuffer with format %{public}@ and frame capacity %d",
+                     stringDescribingAVAudioFormat(converter_.inputFormat), frameCapacity);
         return false;
     }
 

--- a/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
+++ b/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
@@ -921,7 +921,7 @@ bool sfb::AudioPlayer::seekInTime(NSTimeInterval secondsToSkip) noexcept {
         return true;
     }
 
-    const auto framesToSkip = secondsToSkip * decoderState->sampleRate_;
+    const auto framesToSkip = secondsToSkip * decoderState->sampleRate();
     if (framesToSkip >= static_cast<double>(std::numeric_limits<AVAudioFramePosition>::max()) ||
         framesToSkip <= static_cast<double>(std::numeric_limits<AVAudioFramePosition>::min())) {
         return false;
@@ -942,7 +942,7 @@ bool sfb::AudioPlayer::seekToTime(NSTimeInterval timeInSeconds) noexcept {
         return false;
     }
 
-    const auto requestedFrame = timeInSeconds * decoderState->sampleRate_;
+    const auto requestedFrame = timeInSeconds * decoderState->sampleRate();
     if (requestedFrame >= static_cast<double>(std::numeric_limits<AVAudioFramePosition>::max())) {
         return false;
     }
@@ -1977,7 +1977,7 @@ bool sfb::AudioPlayer::processFramesRenderedEvent() noexcept {
                 (*iter)->setFlags(DecoderState::Flags::renderingStarted);
 
                 const auto frameOffset = framesRendered - framesRemainingToDistribute;
-                const double deltaSeconds = frameOffset / (*iter)->sampleRate_;
+                const double deltaSeconds = frameOffset / (*iter)->sampleRate();
                 uint64_t eventTime =
                         hostTime + host_time::fromNanoseconds(static_cast<uint64_t>(deltaSeconds * rateScalar * 1e9));
 
@@ -1998,7 +1998,7 @@ bool sfb::AudioPlayer::processFramesRenderedEvent() noexcept {
             if (bits::is_set_without(flags, DecoderState::Flags::decodingComplete, DecoderState::Flags::isCanceled) &&
                 framesFromThisDecoder == decoderFramesRemaining) {
                 const auto frameOffset = framesRendered - framesRemainingToDistribute;
-                const double deltaSeconds = frameOffset / (*iter)->sampleRate_;
+                const double deltaSeconds = frameOffset / (*iter)->sampleRate();
                 uint64_t eventTime =
                         hostTime + host_time::fromNanoseconds(static_cast<uint64_t>(deltaSeconds * rateScalar * 1e9));
 

--- a/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
+++ b/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
@@ -328,7 +328,7 @@ inline bool AudioPlayer::DecoderState::allocate(AVAudioFrameCount frameCapacity)
 
     decodeBuffer_ = [[AVAudioPCMBuffer alloc] initWithPCMFormat:converter_.inputFormat frameCapacity:frameCapacity];
     if (decodeBuffer_ == nil) {
-        os_log_error(log_, "Error allocating AVAudioPCMBuffer with format %{public}@ and frame capacity %d",
+        os_log_error(log_, "Error creating AVAudioPCMBuffer with format %{public}@ and frame capacity %d",
                      stringDescribingAVAudioFormat(converter_.inputFormat), frameCapacity);
         return false;
     }

--- a/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
+++ b/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
@@ -273,6 +273,7 @@ struct AudioPlayer::DecoderState final {
     }
 
     DecoderState(Decoder _Nonnull decoder) noexcept;
+
     bool allocate(AVAudioFrameCount frameCapacity) noexcept;
 
     double sampleRate() const noexcept;

--- a/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
+++ b/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
@@ -327,7 +327,7 @@ inline bool AudioPlayer::DecoderState::allocate(AVAudioFrameCount frameCapacity)
 
     decodeBuffer_ = [[AVAudioPCMBuffer alloc] initWithPCMFormat:converter_.inputFormat frameCapacity:frameCapacity];
     if (decodeBuffer_ == nil) {
-        os_log_error(log_, "Error creating AVAudioPCMBuffer with format %{public}@ and frame capacity %d",
+        os_log_error(log_, "Error creating AVAudioPCMBuffer with format %{public}@ and frame capacity %u",
                      stringDescribingAVAudioFormat(converter_.inputFormat), frameCapacity);
         return false;
     }
@@ -1387,7 +1387,7 @@ void sfb::AudioPlayer::processDecoders(std::stop_token stoken) noexcept {
                                                                frameCapacity:ringBufferChunkSize];
                         if (buffer == nil) {
                             os_log_error(log_,
-                                         "Error creating AVAudioPCMBuffer with format %{public}@ and frame capacity %d",
+                                         "Error creating AVAudioPCMBuffer with format %{public}@ and frame capacity %u",
                                          stringDescribingAVAudioFormat(renderFormat), ringBufferChunkSize);
                             decoderState->error_ = [NSError errorWithDomain:SFBAudioPlayerErrorDomain
                                                                        code:SFBAudioPlayerErrorCodeInternalError
@@ -1432,7 +1432,7 @@ void sfb::AudioPlayer::processDecoders(std::stop_token stoken) noexcept {
                                                                frameCapacity:ringBufferChunkSize];
                         if (buffer == nil) {
                             os_log_error(log_,
-                                         "Error creating AVAudioPCMBuffer with format %{public}@ and frame capacity %d",
+                                         "Error creating AVAudioPCMBuffer with format %{public}@ and frame capacity %u",
                                          stringDescribingAVAudioFormat(renderFormat), ringBufferChunkSize);
                             decoderState->error_ = [NSError errorWithDomain:SFBAudioPlayerErrorDomain
                                                                        code:SFBAudioPlayerErrorCodeInternalError

--- a/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
+++ b/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
@@ -205,9 +205,7 @@ struct AudioPlayer::DecoderState final {
     const Decoder decoder_{nil};
 
     /// The sample rate of the audio converter's output format
-    const double sampleRate_{0};
-    /// The total number of audio frames
-    const AVAudioFramePosition frameLength_{SFBUnknownFrameLength};
+    std::atomic<double> sampleRate_{0};
 
     /// Flags
     std::atomic_uint flags_{0};
@@ -217,6 +215,8 @@ struct AudioPlayer::DecoderState final {
     std::atomic_int64_t framesDecoded_{0};
     /// The number of frames rendered
     std::atomic_int64_t framesRendered_{0};
+    /// The total number of audio frames
+    std::atomic_int64_t frameLength_{SFBUnknownFrameLength};
     /// The requested frame
     std::atomic_int64_t requestedFrame_{SFBUnknownFramePosition};
 
@@ -248,6 +248,8 @@ struct AudioPlayer::DecoderState final {
         cancelRequested = 1u << 6,
         /// Decoder canceled
         isCanceled = 1u << 7,
+        /// Decoder not initialized
+        needsInitialization = 1u << 8,
     };
 
     // Enable bitmask operations for `Flags`
@@ -271,7 +273,10 @@ struct AudioPlayer::DecoderState final {
         return static_cast<Flags>(flags_.fetch_and(~bits::to_underlying(flags), order));
     }
 
-    DecoderState(Decoder _Nonnull decoder, AVAudioFrameCount frameCapacity);
+    DecoderState(Decoder _Nonnull decoder) noexcept;
+    bool allocate(AVAudioFrameCount frameCapacity, NSError **error) noexcept;
+
+    double sampleRate() const noexcept;
 
     AVAudioFramePosition framePosition() const noexcept;
     AVAudioFramePosition frameLength() const noexcept;
@@ -286,27 +291,54 @@ struct AudioPlayer::DecoderState final {
 
 uint64_t AudioPlayer::DecoderState::sequenceCounter_ = 1;
 
-inline AudioPlayer::DecoderState::DecoderState(Decoder _Nonnull decoder, AVAudioFrameCount frameCapacity)
-    : decoder_{decoder}, sampleRate_{decoder.processingFormat.sampleRate}, frameLength_{decoder.frameLength} {
+inline AudioPlayer::DecoderState::DecoderState(Decoder _Nonnull decoder) noexcept
+    : decoder_{decoder}, flags_{bits::to_underlying(Flags::needsInitialization)} {
 #if DEBUG
     assert(decoder != nil);
+#endif /* DEBUG */
+}
+
+inline bool AudioPlayer::DecoderState::allocate(AVAudioFrameCount frameCapacity, NSError **error) noexcept {
+#if DEBUG
+    assert(converter_ == nil);
+    assert(decodeBuffer_ == nil);
     assert(frameCapacity != 0);
+    assert(bits::is_set(loadFlags(), Flags::needsInitialization));
 #endif /* DEBUG */
 
     if (decoder_ == nil) {
-        throw std::invalid_argument("Decoder may not be nil");
+        os_log_error(log_, "Decoder may not be nil");
+        return false;
+    }
+
+    if (frameCapacity == 0) {
+        os_log_error(log_, "Frame capacity may not be zero");
+        return false;
+    }
+
+    // Open the decoder if necessary
+    if (NSError *err = nil; !decoder_.isOpen && ![decoder_ openReturningError:&err]) {
+        os_log_error(log_, "Error opening %{public}@: %{public}@", decoder_, err);
+        if (error != nullptr) {
+            *error = err;
+        }
+        return false;
     }
 
     auto format = decoder_.processingFormat;
+#if DEBUG
+    assert(format.streamDescription->mFormatID == kAudioFormatLinearPCM);
+#endif /* DEBUG */
     if (format == nil || format.streamDescription->mFormatID != kAudioFormatLinearPCM) {
-        throw std::invalid_argument("Decoder processing format must be PCM");
+        os_log_error(log_, "Decoder processing format must be PCM");
+        return false;
     }
 
     auto standardEquivalentFormat = format.standardEquivalent;
     if (standardEquivalentFormat == nil) {
         os_log_error(log_, "Error converting %{public}@ to standard equivalent format",
                      stringDescribingAVAudioFormat(format));
-        throw std::runtime_error("Error creating standard equivalent format");
+        return false;
     }
 
     // Convert to deinterleaved native-endian float, preserving the channel count and order
@@ -314,25 +346,36 @@ inline AudioPlayer::DecoderState::DecoderState(Decoder _Nonnull decoder, AVAudio
     if (converter_ == nil) {
         os_log_error(log_, "Error creating AVAudioConverter converting from %{public}@ to %{public}@",
                      stringDescribingAVAudioFormat(format), stringDescribingAVAudioFormat(standardEquivalentFormat));
-        throw std::runtime_error("Error creating AVAudioConverter");
+        return false;
     }
 
     decodeBuffer_ = [[AVAudioPCMBuffer alloc] initWithPCMFormat:converter_.inputFormat frameCapacity:frameCapacity];
     if (decodeBuffer_ == nil) {
         os_log_error(log_, "Error allocating AVAudioPCMBuffer");
-        throw std::runtime_error("Error allocating AVAudioPCMBuffer");
+        return false;
     }
 
     const auto framePosition = decoder_.framePosition;
     if (framePosition == SFBUnknownFramePosition) {
-        os_log_error(log_, "Unknown frame position in decoder");
-        throw std::runtime_error("Unknown frame position in decoder");
+        os_log_error(log_, "Unknown frame position in %{public}@", decoder_);
+        return false;
     }
 
     if (framePosition != 0) {
         framesDecoded_.store(framePosition, std::memory_order_release);
         framesRendered_.store(framePosition, std::memory_order_release);
     }
+
+    sampleRate_.store(format.sampleRate, std::memory_order_release);
+    frameLength_.store(decoder_.frameLength);
+
+    clearFlags(Flags::needsInitialization);
+
+    return true;
+}
+
+inline double AudioPlayer::DecoderState::sampleRate() const noexcept {
+    return sampleRate_.load(std::memory_order_acquire);
 }
 
 inline AVAudioFramePosition AudioPlayer::DecoderState::framePosition() const noexcept {
@@ -342,7 +385,9 @@ inline AVAudioFramePosition AudioPlayer::DecoderState::framePosition() const noe
     return framesRendered_.load(std::memory_order_acquire);
 }
 
-inline AVAudioFramePosition AudioPlayer::DecoderState::frameLength() const noexcept { return frameLength_; }
+inline AVAudioFramePosition AudioPlayer::DecoderState::frameLength() const noexcept {
+    return frameLength_.load(std::memory_order_acquire);
+}
 
 inline bool AudioPlayer::DecoderState::decodeAudio(AVAudioPCMBuffer *_Nonnull buffer, NSError **error) noexcept {
 #if DEBUG
@@ -833,7 +878,7 @@ SFBPlaybackTime sfb::AudioPlayer::playbackTime() const noexcept {
     const auto framePosition = decoderState->framePosition();
     const auto frameLength = decoderState->frameLength();
 
-    if (const auto sampleRate = decoderState->sampleRate_; sampleRate > 0) {
+    if (const auto sampleRate = decoderState->sampleRate(); sampleRate > 0) {
         if (framePosition != SFBUnknownFramePosition) {
             playbackTime.currentTime = framePosition / sampleRate;
         }
@@ -868,7 +913,7 @@ bool sfb::AudioPlayer::getPlaybackPositionAndTime(SFBPlaybackPosition *playbackP
 
     if (playbackTime != nullptr) {
         SFBPlaybackTime currentPlaybackTime = SFBInvalidPlaybackTime;
-        if (const auto sampleRate = decoderState->sampleRate_; sampleRate > 0) {
+        if (const auto sampleRate = decoderState->sampleRate(); sampleRate > 0) {
             if (currentPlaybackPosition.framePosition != SFBUnknownFramePosition) {
                 currentPlaybackTime.currentTime = currentPlaybackPosition.framePosition / sampleRate;
             }
@@ -1291,46 +1336,50 @@ void sfb::AudioPlayer::processDecoders(std::stop_token stoken) noexcept {
 
         // Dequeue the next decoder if there are no decoders that haven't completed decoding
         if (decoderState == nullptr) {
-            Decoder decoder = nil;
-            if (std::lock_guard lock{queuedDecodersMutex_}; !queuedDecoders_.empty()) {
-                // Pop the first decoder from the decoder queue
-                decoder = queuedDecoders_.front();
-                queuedDecoders_.pop_front();
-                setFlags(Flags::decoderDequeued);
+            {
+                // Lock both mutexes to ensure a decoder doesn't momentarily "disappear"
+                // when transitioning from queued to active
+                std::scoped_lock lock{queuedDecodersMutex_, activeDecodersMutex_};
+
+                if (!queuedDecoders_.empty()) {
+                    // Remove the first decoder from the decoder queue
+                    auto decoder = queuedDecoders_.front();
+                    queuedDecoders_.pop_front();
+
+                    // Create the decoder state and add it to the list of active decoders
+                    try {
+                        activeDecoders_.push_back(std::make_unique<DecoderState>(decoder));
+#if DEBUG
+                        assert(std::ranges::is_sorted(activeDecoders_, std::ranges::less{},
+                                                      &DecoderState::sequenceNumber_));
+#endif /* DEBUG */
+                        decoderState = activeDecoders_.back().get();
+                    } catch (const std::exception &e) {
+                        os_log_error(log_, "Error creating decoder state for %{public}@: %{public}s", decoder,
+                                     e.what());
+                        submitDecodingErrorEvent([NSError errorWithDomain:SFBAudioPlayerErrorDomain
+                                                                     code:SFBAudioPlayerErrorCodeInternalError
+                                                                 userInfo:nil]);
+                        continue;
+                    }
+                }
             }
 
-            if (decoder != nil) {
-                // Open the decoder if necessary
-                if (NSError *error = nil; !decoder.isOpen && ![decoder openReturningError:&error]) {
-                    os_log_error(log_, "Error opening %{public}@: %{public}@", decoder, error);
-                    submitDecodingErrorEvent(error);
-                    clearFlags(Flags::decoderDequeued);
+            if (decoderState != nullptr) {
+                // Allocate decoder state internals
+                if (NSError *error = nil; !decoderState->allocate(ringBufferChunkSize, &error)) {
+                    os_log_error(log_,
+                                 "Error allocating decoder state data: DecoderStateData::allocate failed with frame "
+                                 "capacity %d: %{public}@",
+                                 ringBufferChunkSize, error);
+                    decoderState->error_ = [NSError errorWithDomain:SFBAudioPlayerErrorDomain
+                                                               code:SFBAudioPlayerErrorCodeInternalError
+                                                           userInfo:nil];
+                    decoderState->setFlags(DecoderState::Flags::cancelRequested);
                     continue;
                 }
 
-                // Create the decoder state and add it to the list of active decoders
-                try {
-                    auto nextDecoderState = std::make_unique<DecoderState>(decoder, ringBufferChunkSize);
-
-                    std::lock_guard lock{activeDecodersMutex_};
-                    activeDecoders_.push_back(std::move(nextDecoderState));
-                    clearFlags(Flags::decoderDequeued);
-
-#if DEBUG
-                    assert(std::ranges::is_sorted(activeDecoders_, std::ranges::less{},
-                                                  &DecoderState::sequenceNumber_));
-#endif /* DEBUG */
-
-                    decoderState = activeDecoders_.back().get();
-                    os_log_debug(log_, "Dequeued %{public}@", decoderState->decoder_);
-                } catch (const std::exception &e) {
-                    os_log_error(log_, "Error creating decoder state for %{public}@: %{public}s", decoder, e.what());
-                    submitDecodingErrorEvent([NSError errorWithDomain:SFBAudioPlayerErrorDomain
-                                                                 code:SFBAudioPlayerErrorCodeInternalError
-                                                             userInfo:nil]);
-                    clearFlags(Flags::decoderDequeued);
-                    continue;
-                }
+                os_log_debug(log_, "Dequeued %{public}@", decoderState->decoder_);
             }
         }
 
@@ -1803,7 +1852,7 @@ bool sfb::AudioPlayer::processDecoderCanceledEvent() noexcept {
         return queuedDecoders_.empty() && activeDecoders_.empty();
     }();
 
-    if (hasNoDecoders && bits::is_clear(loadFlags(), Flags::decoderDequeued)) {
+    if (hasNoDecoders) {
         setNowPlaying(nil);
 
         const auto didStopEngine = stopEngineIfRunning();
@@ -2116,7 +2165,7 @@ void sfb::AudioPlayer::handleRenderingWillCompleteEvent(Decoder decoder, uint64_
         }();
 
         // End of audio
-        if (hasNoDecoders && bits::is_clear(that->loadFlags(), Flags::decoderDequeued)) {
+        if (hasNoDecoders) {
 #if DEBUG
             os_log_debug(log_, "End of audio reached");
 #endif /* DEBUG */
@@ -2175,7 +2224,7 @@ sfb::AudioPlayer::DecoderState *sfb::AudioPlayer::firstActiveDecoderState() cons
 
     const auto iter = std::ranges::find_if(activeDecoders_, [](const auto &decoderState) {
         const auto flags = decoderState->loadFlags();
-        return bits::is_clear(flags, DecoderState::Flags::isCanceled);
+        return bits::has_none(flags, DecoderState::Flags::needsInitialization | DecoderState::Flags::isCanceled);
     });
     if (iter == activeDecoders_.cend()) {
         return nullptr;

--- a/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
+++ b/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
@@ -1346,11 +1346,8 @@ void sfb::AudioPlayer::processDecoders(std::stop_token stoken) noexcept {
                 if (!decoderState->decoder_.isOpen) {
                     if (NSError *error = nil; ![decoderState->decoder_ openReturningError:&error]) {
                         os_log_error(log_, "Error opening %{public}@: %{public}@", decoderState->decoder_, error);
-                        {
-                            std::lock_guard lock{activeDecodersMutex_};
-                            activeDecoders_.pop_back();
-                        }
-                        submitDecodingErrorEvent(error);
+                        decoderState->error_ = error;
+                        decoderState->setFlags(DecoderState::Flags::cancelRequested);
                         continue;
                     }
 
@@ -1366,13 +1363,10 @@ void sfb::AudioPlayer::processDecoders(std::stop_token stoken) noexcept {
                                  "Error allocating decoder state data: DecoderStateData::allocate failed with frame "
                                  "capacity %d",
                                  ringBufferChunkSize);
-                    submitDecodingErrorEvent([NSError errorWithDomain:SFBAudioPlayerErrorDomain
-                                                                 code:SFBAudioPlayerErrorCodeInternalError
-                                                             userInfo:nil]);
-                    {
-                        std::lock_guard lock{activeDecodersMutex_};
-                        activeDecoders_.pop_back();
-                    }
+                    decoderState->error_ = [NSError errorWithDomain:SFBAudioPlayerErrorDomain
+                                                               code:SFBAudioPlayerErrorCodeInternalError
+                                                           userInfo:nil];
+                    decoderState->setFlags(DecoderState::Flags::cancelRequested);
                     continue;
                 }
 
@@ -1821,7 +1815,9 @@ bool sfb::AudioPlayer::processDecoderCanceledEvent() noexcept {
             iter != activeDecoders_.cend()) {
             decoder = (*iter)->decoder_;
             error = (*iter)->error_;
-            framesRendered = (*iter)->framesRendered_.load(std::memory_order_acquire);
+            if (bits::is_clear((*iter)->loadFlags(), DecoderState::Flags::needsInitialization)) {
+                framesRendered = (*iter)->framesRendered_.load(std::memory_order_acquire);
+            }
 
             os_log_debug(log_, "Deleting decoder state for %{public}@", (*iter)->decoder_);
             activeDecoders_.erase(iter);

--- a/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
+++ b/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
@@ -1949,6 +1949,12 @@ bool sfb::AudioPlayer::processFramesRenderedEvent() noexcept {
         while (iter != activeDecoders_.cend()) {
             const auto flags = (*iter)->loadFlags();
 
+            // Skip unitialized decoders
+            if (bits::is_set(flags, DecoderState::Flags::needsInitialization)) {
+                ++iter;
+                continue;
+            }
+
             // If a frames rendered event was posted it means valid frames were rendered
             // during that render cycle.
             //

--- a/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
+++ b/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
@@ -289,8 +289,7 @@ struct AudioPlayer::DecoderState final {
 
 uint64_t AudioPlayer::DecoderState::sequenceCounter_ = 1;
 
-inline AudioPlayer::DecoderState::DecoderState(Decoder _Nonnull decoder) noexcept
-    : decoder_{decoder} {
+inline AudioPlayer::DecoderState::DecoderState(Decoder _Nonnull decoder) noexcept : decoder_{decoder} {
 #if DEBUG
     assert(decoder != nil);
 #endif /* DEBUG */
@@ -347,9 +346,7 @@ inline AVAudioFramePosition AudioPlayer::DecoderState::framePosition() const noe
     return framesRendered_.load(std::memory_order_acquire);
 }
 
-inline AVAudioFramePosition AudioPlayer::DecoderState::frameLength() const noexcept {
-    return frameLength_;
-}
+inline AVAudioFramePosition AudioPlayer::DecoderState::frameLength() const noexcept { return frameLength_; }
 
 inline bool AudioPlayer::DecoderState::decodeAudio(AVAudioPCMBuffer *_Nonnull buffer, NSError **error) noexcept {
 #if DEBUG
@@ -1327,7 +1324,8 @@ void sfb::AudioPlayer::processDecoders(std::stop_token stoken) noexcept {
 
             if (decoderState != nullptr) {
                 // Open the decoder if necessary
-                if (NSError *error = nil; !decoderState->decoder_.isOpen && ![decoderState->decoder_ openReturningError:&error]) {
+                if (NSError *error = nil;
+                    !decoderState->decoder_.isOpen && ![decoderState->decoder_ openReturningError:&error]) {
                     os_log_error(log_, "Error opening %{public}@: %{public}@", decoderState->decoder_, error);
                     decoderState->error_ = error;
                     decoderState->setFlags(DecoderState::Flags::cancelRequested);

--- a/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
+++ b/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
@@ -300,20 +300,17 @@ inline AudioPlayer::DecoderState::DecoderState(Decoder _Nonnull decoder) noexcep
 
 inline bool AudioPlayer::DecoderState::allocate(AVAudioFrameCount frameCapacity) noexcept {
 #if DEBUG
+    assert(decoder_.isOpen);
     assert(converter_ == nil);
     assert(decodeBuffer_ == nil);
-    assert(frameCapacity != 0);
     assert(bits::is_set(loadFlags(), Flags::needsInitialization));
+    assert(frameCapacity != 0);
 #endif /* DEBUG */
 
     auto format = decoder_.processingFormat;
 #if DEBUG
     assert(format.streamDescription->mFormatID == kAudioFormatLinearPCM);
 #endif /* DEBUG */
-    if (format == nil || format.streamDescription->mFormatID != kAudioFormatLinearPCM) {
-        os_log_error(log_, "Decoder processing format must be PCM");
-        return false;
-    }
 
     auto standardEquivalentFormat = format.standardEquivalent;
     if (standardEquivalentFormat == nil) {

--- a/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
+++ b/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
@@ -273,7 +273,7 @@ struct AudioPlayer::DecoderState final {
     }
 
     DecoderState(Decoder _Nonnull decoder) noexcept;
-    bool allocate(AVAudioFrameCount frameCapacity, NSError **error) noexcept;
+    bool allocate(AVAudioFrameCount frameCapacity) noexcept;
 
     double sampleRate() const noexcept;
 
@@ -297,32 +297,13 @@ inline AudioPlayer::DecoderState::DecoderState(Decoder _Nonnull decoder) noexcep
 #endif /* DEBUG */
 }
 
-inline bool AudioPlayer::DecoderState::allocate(AVAudioFrameCount frameCapacity, NSError **error) noexcept {
+inline bool AudioPlayer::DecoderState::allocate(AVAudioFrameCount frameCapacity) noexcept {
 #if DEBUG
     assert(converter_ == nil);
     assert(decodeBuffer_ == nil);
     assert(frameCapacity != 0);
     assert(bits::is_set(loadFlags(), Flags::needsInitialization));
 #endif /* DEBUG */
-
-    if (decoder_ == nil) {
-        os_log_error(log_, "Decoder may not be nil");
-        return false;
-    }
-
-    if (frameCapacity == 0) {
-        os_log_error(log_, "Frame capacity may not be zero");
-        return false;
-    }
-
-    // Open the decoder if necessary
-    if (NSError *err = nil; !decoder_.isOpen && ![decoder_ openReturningError:&err]) {
-        os_log_error(log_, "Error opening %{public}@: %{public}@", decoder_, err);
-        if (error != nullptr) {
-            *error = err;
-        }
-        return false;
-    }
 
     auto format = decoder_.processingFormat;
 #if DEBUG
@@ -1365,12 +1346,21 @@ void sfb::AudioPlayer::processDecoders(std::stop_token stoken) noexcept {
             }
 
             if (decoderState != nullptr) {
+                // Open the decoder if necessary
+                if (NSError *error = nil;
+                    !decoderState->decoder_.isOpen && ![decoderState->decoder_ openReturningError:&error]) {
+                    os_log_error(log_, "Error opening %{public}@: %{public}@", decoderState->decoder_, error);
+                    decoderState->error_ = error;
+                    decoderState->setFlags(DecoderState::Flags::cancelRequested);
+                    continue;
+                }
+
                 // Allocate decoder state internals
-                if (NSError *error = nil; !decoderState->allocate(ringBufferChunkSize, &error)) {
+                if (!decoderState->allocate(ringBufferChunkSize)) {
                     os_log_error(log_,
                                  "Error allocating decoder state data: DecoderStateData::allocate failed with frame "
-                                 "capacity %d: %{public}@",
-                                 ringBufferChunkSize, error);
+                                 "capacity %d",
+                                 ringBufferChunkSize);
                     decoderState->error_ = [NSError errorWithDomain:SFBAudioPlayerErrorDomain
                                                                code:SFBAudioPlayerErrorCodeInternalError
                                                            userInfo:nil];

--- a/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
+++ b/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
@@ -203,32 +203,6 @@ struct AudioPlayer::DecoderState final {
     /// Decodes audio from the source representation to PCM
     const Decoder decoder_{nil};
 
-    /// The sample rate of the audio converter's output format
-    double sampleRate_{0};
-
-    /// Flags
-    std::atomic_uint flags_{0};
-    static_assert(std::atomic_uint::is_always_lock_free, "Lock-free std::atomic_uint required");
-
-    /// The number of frames decoded
-    std::atomic_int64_t framesDecoded_{0};
-    /// The number of frames rendered
-    std::atomic_int64_t framesRendered_{0};
-    /// The total number of audio frames
-    AVAudioFramePosition frameLength_{SFBUnknownFrameLength};
-    /// The requested frame
-    std::atomic_int64_t requestedFrame_{SFBUnknownFramePosition};
-
-    static_assert(std::atomic_int64_t::is_always_lock_free, "Lock-free std::atomic_int64_t required");
-
-    /// Converts audio from the decoder's processing format to the equivalent standard format
-    AVAudioConverter *converter_{nil};
-    /// Buffer used internally for buffering during conversion
-    AVAudioPCMBuffer *decodeBuffer_{nil};
-
-    /// The error that caused decoding to abort, if any
-    NSError *error_{nil};
-
     /// Possible bits in `flags_`
     enum class Flags : unsigned int {
         /// Decoding started
@@ -250,6 +224,32 @@ struct AudioPlayer::DecoderState final {
         /// Decoder state not initialized
         needsInitialization = 1u << 8,
     };
+
+    /// Flags
+    std::atomic_uint flags_{bits::to_underlying(Flags::needsInitialization)};
+    static_assert(std::atomic_uint::is_always_lock_free, "Lock-free std::atomic_uint required");
+
+    /// The number of frames decoded
+    std::atomic_int64_t framesDecoded_{0};
+    /// The number of frames rendered
+    std::atomic_int64_t framesRendered_{0};
+    /// The total number of audio frames
+    AVAudioFramePosition frameLength_{SFBUnknownFrameLength};
+    /// The requested frame
+    std::atomic_int64_t requestedFrame_{SFBUnknownFramePosition};
+
+    static_assert(std::atomic_int64_t::is_always_lock_free, "Lock-free std::atomic_int64_t required");
+
+    /// Converts audio from the decoder's processing format to the equivalent standard format
+    AVAudioConverter *converter_{nil};
+    /// Buffer used internally for buffering during conversion
+    AVAudioPCMBuffer *decodeBuffer_{nil};
+
+    /// The sample rate of the audio converter's output format
+    double sampleRate_{0};
+
+    /// The error that caused decoding to abort, if any
+    NSError *error_{nil};
 
     // Enable bitmask operations for `Flags`
     friend constexpr void is_bitmask_enum(Flags);
@@ -292,7 +292,7 @@ struct AudioPlayer::DecoderState final {
 uint64_t AudioPlayer::DecoderState::sequenceCounter_ = 1;
 
 inline AudioPlayer::DecoderState::DecoderState(Decoder _Nonnull decoder) noexcept
-    : decoder_{decoder}, flags_{bits::to_underlying(Flags::needsInitialization)} {
+    : decoder_{decoder} {
 #if DEBUG
     assert(decoder != nil);
 #endif /* DEBUG */
@@ -1815,9 +1815,7 @@ bool sfb::AudioPlayer::processDecoderCanceledEvent() noexcept {
             iter != activeDecoders_.cend()) {
             decoder = (*iter)->decoder_;
             error = (*iter)->error_;
-            if (bits::is_clear((*iter)->loadFlags(), DecoderState::Flags::needsInitialization)) {
-                framesRendered = (*iter)->framesRendered_.load(std::memory_order_acquire);
-            }
+            framesRendered = (*iter)->framesRendered_.load(std::memory_order_acquire);
 
             os_log_debug(log_, "Deleting decoder state for %{public}@", (*iter)->decoder_);
             activeDecoders_.erase(iter);

--- a/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
+++ b/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
@@ -2116,7 +2116,7 @@ void sfb::AudioPlayer::handleRenderingWillCompleteEvent(Decoder decoder, uint64_
         }();
 
         // End of audio
-        if (hasNoDecoders && bits::is_clear(loadFlags(), Flags::decoderDequeued)) {
+        if (hasNoDecoders && bits::is_clear(that->loadFlags(), Flags::decoderDequeued)) {
 #if DEBUG
             os_log_debug(log_, "End of audio reached");
 #endif /* DEBUG */

--- a/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
+++ b/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
@@ -1346,8 +1346,11 @@ void sfb::AudioPlayer::processDecoders(std::stop_token stoken) noexcept {
                 if (!decoderState->decoder_.isOpen) {
                     if (NSError *error = nil; ![decoderState->decoder_ openReturningError:&error]) {
                         os_log_error(log_, "Error opening %{public}@: %{public}@", decoderState->decoder_, error);
-                        decoderState->error_ = error;
-                        decoderState->setFlags(DecoderState::Flags::cancelRequested);
+                        {
+                            std::lock_guard lock{activeDecodersMutex_};
+                            activeDecoders_.pop_back();
+                        }
+                        submitDecodingErrorEvent(error);
                         continue;
                     }
 
@@ -1363,10 +1366,13 @@ void sfb::AudioPlayer::processDecoders(std::stop_token stoken) noexcept {
                                  "Error allocating decoder state data: DecoderStateData::allocate failed with frame "
                                  "capacity %d",
                                  ringBufferChunkSize);
-                    decoderState->error_ = [NSError errorWithDomain:SFBAudioPlayerErrorDomain
-                                                               code:SFBAudioPlayerErrorCodeInternalError
-                                                           userInfo:nil];
-                    decoderState->setFlags(DecoderState::Flags::cancelRequested);
+                    submitDecodingErrorEvent([NSError errorWithDomain:SFBAudioPlayerErrorDomain
+                                                                 code:SFBAudioPlayerErrorCodeInternalError
+                                                             userInfo:nil]);
+                    {
+                        std::lock_guard lock{activeDecodersMutex_};
+                        activeDecoders_.pop_back();
+                    }
                     continue;
                 }
 

--- a/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
+++ b/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
@@ -353,9 +353,7 @@ inline bool AudioPlayer::DecoderState::allocate(AVAudioFrameCount frameCapacity)
     return true;
 }
 
-inline double AudioPlayer::DecoderState::sampleRate() const noexcept {
-    return sampleRate_;
-}
+inline double AudioPlayer::DecoderState::sampleRate() const noexcept { return sampleRate_; }
 
 inline AVAudioFramePosition AudioPlayer::DecoderState::framePosition() const noexcept {
     if (bits::is_set(loadFlags(), Flags::seekPending)) {
@@ -364,9 +362,7 @@ inline AVAudioFramePosition AudioPlayer::DecoderState::framePosition() const noe
     return framesRendered_.load(std::memory_order_acquire);
 }
 
-inline AVAudioFramePosition AudioPlayer::DecoderState::frameLength() const noexcept {
-    return frameLength_;
-}
+inline AVAudioFramePosition AudioPlayer::DecoderState::frameLength() const noexcept { return frameLength_; }
 
 inline bool AudioPlayer::DecoderState::decodeAudio(AVAudioPCMBuffer *_Nonnull buffer, NSError **error) noexcept {
 #if DEBUG

--- a/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
+++ b/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
@@ -291,8 +291,7 @@ struct AudioPlayer::DecoderState final {
 
 uint64_t AudioPlayer::DecoderState::sequenceCounter_ = 1;
 
-inline AudioPlayer::DecoderState::DecoderState(Decoder _Nonnull decoder) noexcept
-    : decoder_{decoder} {
+inline AudioPlayer::DecoderState::DecoderState(Decoder _Nonnull decoder) noexcept : decoder_{decoder} {
 #if DEBUG
     assert(decoder != nil);
 #endif /* DEBUG */

--- a/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
+++ b/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
@@ -1324,8 +1324,7 @@ void sfb::AudioPlayer::processDecoders(std::stop_token stoken) noexcept {
                     decoderState = activeDecoders_.back().get();
                     os_log_debug(log_, "Dequeued %{public}@", decoderState->decoder_);
                 } catch (const std::exception &e) {
-                    os_log_error(log_, "Error creating decoder state for %{public}@: %{public}s", decoder,
-                                 e.what());
+                    os_log_error(log_, "Error creating decoder state for %{public}@: %{public}s", decoder, e.what());
                     submitDecodingErrorEvent([NSError errorWithDomain:SFBAudioPlayerErrorDomain
                                                                  code:SFBAudioPlayerErrorCodeInternalError
                                                              userInfo:nil]);

--- a/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
+++ b/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
@@ -328,7 +328,7 @@ inline bool AudioPlayer::DecoderState::allocate(AVAudioFrameCount frameCapacity)
 
     decodeBuffer_ = [[AVAudioPCMBuffer alloc] initWithPCMFormat:converter_.inputFormat frameCapacity:frameCapacity];
     if (decodeBuffer_ == nil) {
-        os_log_error(log_, "Error allocating AVAudioPCMBuffer");
+        os_log_error(log_, "Error allocating AVAudioPCMBuffer with format %{public}@ and frame capacity %d", stringDescribingAVAudioFormat(converter_.inputFormat), frameCapacity);
         return false;
     }
 

--- a/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
+++ b/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
@@ -311,7 +311,6 @@ inline bool AudioPlayer::DecoderState::allocate(AVAudioFrameCount frameCapacity)
 #if DEBUG
     assert(format.streamDescription->mFormatID == kAudioFormatLinearPCM);
 #endif /* DEBUG */
-
     auto standardEquivalentFormat = format.standardEquivalent;
     if (standardEquivalentFormat == nil) {
         os_log_error(log_, "Error converting %{public}@ to standard equivalent format",

--- a/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
+++ b/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
@@ -1343,12 +1343,18 @@ void sfb::AudioPlayer::processDecoders(std::stop_token stoken) noexcept {
 
             if (decoderState != nullptr) {
                 // Open the decoder if necessary
-                if (NSError *error = nil;
-                    !decoderState->decoder_.isOpen && ![decoderState->decoder_ openReturningError:&error]) {
-                    os_log_error(log_, "Error opening %{public}@: %{public}@", decoderState->decoder_, error);
-                    decoderState->error_ = error;
-                    decoderState->setFlags(DecoderState::Flags::cancelRequested);
-                    continue;
+                if (!decoderState->decoder_.isOpen) {
+                    if (NSError *error = nil; ![decoderState->decoder_ openReturningError:&error]) {
+                        os_log_error(log_, "Error opening %{public}@: %{public}@", decoderState->decoder_, error);
+                        decoderState->error_ = error;
+                        decoderState->setFlags(DecoderState::Flags::cancelRequested);
+                        continue;
+                    }
+
+                    // Short-circuit processing if the decoder was canceled during open
+                    if (bits::is_set(decoderState->loadFlags(), DecoderState::Flags::cancelRequested)) {
+                        continue;
+                    }
                 }
 
                 // Allocate decoder state internals

--- a/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
+++ b/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
@@ -204,7 +204,9 @@ struct AudioPlayer::DecoderState final {
     const Decoder decoder_{nil};
 
     /// The sample rate of the audio converter's output format
-    const double sampleRate_{0};
+    double sampleRate_{0};
+    /// The total number of audio frames
+    AVAudioFramePosition frameLength_{SFBUnknownFrameLength};
 
     /// Flags
     std::atomic_uint flags_{0};
@@ -216,8 +218,6 @@ struct AudioPlayer::DecoderState final {
     std::atomic_int64_t framesConverted_{0};
     /// The number of frames rendered
     std::atomic_int64_t framesRendered_{0};
-    /// The total number of audio frames
-    std::atomic_int64_t frameLength_{SFBUnknownFrameLength};
     /// The requested frame
     std::atomic_int64_t requestedFrame_{SFBUnknownFramePosition};
 
@@ -290,7 +290,7 @@ struct AudioPlayer::DecoderState final {
 uint64_t AudioPlayer::DecoderState::sequenceCounter_ = 1;
 
 inline AudioPlayer::DecoderState::DecoderState(Decoder _Nonnull decoder) noexcept
-    : decoder_{decoder}, sampleRate_{decoder.processingFormat.sampleRate}, frameLength_{decoder.frameLength} {
+    : decoder_{decoder} {
 #if DEBUG
     assert(decoder != nil);
 #endif /* DEBUG */
@@ -334,6 +334,9 @@ inline bool AudioPlayer::DecoderState::allocate(AVAudioFrameCount frameCapacity)
         framesRendered_.store(framePosition, std::memory_order_release);
     }
 
+    frameLength_ = decoder_.frameLength;
+    sampleRate_ = format.sampleRate;
+
     return true;
 }
 
@@ -345,7 +348,7 @@ inline AVAudioFramePosition AudioPlayer::DecoderState::framePosition() const noe
 }
 
 inline AVAudioFramePosition AudioPlayer::DecoderState::frameLength() const noexcept {
-    return frameLength_.load(std::memory_order_acquire);
+    return frameLength_;
 }
 
 inline bool AudioPlayer::DecoderState::decodeAudio(AVAudioPCMBuffer *_Nonnull buffer, NSError **error) noexcept {
@@ -592,11 +595,6 @@ bool sfb::AudioPlayer::enqueueDecoder(Decoder decoder, bool forImmediatePlayback
 #if DEBUG
     assert(decoder != nil);
 #endif /* DEBUG */
-
-    // Open the decoder if necessary
-    if (!decoder.isOpen && ![decoder openReturningError:error]) {
-        return false;
-    }
 
     // Ensure only one decoder can be enqueued at a time
     std::lock_guard lock{queuedDecodersMutex_};
@@ -1328,6 +1326,14 @@ void sfb::AudioPlayer::processDecoders(std::stop_token stoken) noexcept {
             }
 
             if (decoderState != nullptr) {
+                // Open the decoder if necessary
+                if (NSError *error = nil; !decoderState->decoder_.isOpen && ![decoderState->decoder_ openReturningError:&error]) {
+                    os_log_error(log_, "Error opening %{public}@: %{public}@", decoderState->decoder_, error);
+                    decoderState->error_ = error;
+                    decoderState->setFlags(DecoderState::Flags::cancelRequested);
+                    continue;
+                }
+
                 // Allocate decoder state internals
                 if (!decoderState->allocate(ringBufferChunkSize)) {
                     os_log_error(log_,

--- a/Sources/CSFBAudioEngine/include/SFBAudioEngine/SFBAudioPlayer.h
+++ b/Sources/CSFBAudioEngine/include/SFBAudioEngine/SFBAudioPlayer.h
@@ -106,8 +106,8 @@ NS_SWIFT_NAME(AudioPlayer)
 - (BOOL)enqueueDecoder:(id<SFBPCMDecoding>)decoder error:(NSError **)error NS_SWIFT_NAME(enqueue(_:));
 /// Enqueues a decoder for subsequent playback, optionally canceling the current decoder and clearing any queued
 /// decoders
-/// - note: If `forImmediatePlayback` is `YES`, the audio processing graph is reconfigured for
-/// `decoder.processingFormat` if necessary
+/// - note: The decoder is opened in the decoding thread if required before the decoding process begins. Any errors that
+/// occur during opening are reported asynchronously to the delegate.
 /// - parameter decoder: The decoder to enqueue
 /// - parameter forImmediatePlayback: If `YES` the current decoder is canceled and any queued decoders are cleared
 /// before enqueuing


### PR DESCRIPTION
This PR delays decoder opening until necessary in the decoding thread and also moves the initialization of decoder state properties (which could potentially block) outside the locks.