### PR TITLE
Fix MP4 album metadata atom identifier

### DIFF
--- a/Sources/CSFBAudioEngine/Metadata/SFBAudioMetadata+TagLibMP4Tag.mm
+++ b/Sources/CSFBAudioEngine/Metadata/SFBAudioMetadata+TagLibMP4Tag.mm
@@ -247,7 +247,7 @@ void sfb::setMP4TagFromMetadata(SFBAudioMetadata *metadata, TagLib::MP4::Tag *ta
 
     SetMP4Item(tag, "\251nam", metadata.title);
     SetMP4Item(tag, "\251ART", metadata.artist);
-    SetMP4Item(tag, "\251ALB", metadata.albumTitle);
+    SetMP4Item(tag, "\251alb", metadata.albumTitle);
     SetMP4Item(tag, "aART", metadata.albumArtist);
     SetMP4Item(tag, "\251gen", metadata.genre);
     SetMP4Item(tag, "\251wrt", metadata.composer);


### PR DESCRIPTION
## Summary

The MP4 album atom is currently written using `\251ALB`.

According to the MP4/iTunes metadata specification, the album atom identifier is \251alb (lowercase), not \251ALB.

Because of this typo, album metadata changes are not persisted for MP4/M4A files, while other metadata fields continue to save correctly.

This updates the atom identifier to the correct lowercase value.

## Testing

- Opened an existing M4A file.
- Changed only the album name.
- Saved the file.
- Reopened the file.
- Verified that the updated album name was correctly persisted.