### PR TITLE
AudioPlayer: skip mixer→output reconnection when the output node reports an invalid format

### DIFF
--- a/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
+++ b/Sources/CSFBAudioEngine/Player/AudioPlayer.mm
@@ -2265,11 +2265,23 @@ void sfb::AudioPlayer::handleAudioEngineConfigurationChange(AVAudioEngine *engin
         AVAudioFormat *outputNodeOutputFormat = [outputNode outputFormatForBus:0];
         AVAudioFormat *mixerNodeOutputFormat = [mixerNode outputFormatForBus:0];
 
+        // During a route change, audio interruption, or media services reset the output hardware
+        // can transiently report an invalid (0 Hz / 0 channel) format. Connecting a node using such
+        // a format fails the AVAudioEngine precondition IsFormatSampleRateAndChannelCountValid(),
+        // which raises an Objective-C exception; because this handler is noexcept the exception
+        // terminates the process. Only reconfigure the main mixer → output connection while the
+        // output node reports a usable format. AVAudioEngine posts another configuration change
+        // notification once valid output hardware becomes available, at which point the connection
+        // is updated.
+        const BOOL outputNodeOutputFormatIsValid =
+            outputNodeOutputFormat.sampleRate > 0 && outputNodeOutputFormat.channelCount > 0;
+
         // The output node's output format tracks the hardware sample rate and channel count
         // To avoid format conversion in both the source-mixer and mixer-output connections,
         // set the format for the mixer-output connection to the output node's output format
-        if (outputNodeOutputFormat.sampleRate != mixerNodeOutputFormat.sampleRate ||
-            outputNodeOutputFormat.channelCount != mixerNodeOutputFormat.channelCount) {
+        if (outputNodeOutputFormatIsValid &&
+            (outputNodeOutputFormat.sampleRate != mixerNodeOutputFormat.sampleRate ||
+             outputNodeOutputFormat.channelCount != mixerNodeOutputFormat.channelCount)) {
 #if DEBUG
             if (outputNodeOutputFormat.sampleRate != mixerNodeOutputFormat.sampleRate) {
                 os_log_debug(log_,
@@ -2304,6 +2316,12 @@ void sfb::AudioPlayer::handleAudioEngineConfigurationChange(AVAudioEngine *engin
             [engine_ connect:mixerNode to:outputNode format:outputNodeOutputFormat];
 
             [engine_ prepare];
+        }
+        else if (!outputNodeOutputFormatIsValid) {
+            os_log_error(log_,
+                         "Skipping main mixer → output node reconfiguration: the output node "
+                         "reported an invalid format (%g Hz, %u channels)",
+                         outputNodeOutputFormat.sampleRate, outputNodeOutputFormat.channelCount);
         }
 
         // Restart AVAudioEngine if previously running


### PR DESCRIPTION
_(Hey @sbooth! Although this PR is heavily AI-assisted, I, a RealHuman™, spent a couple hours building it in order to fix a crashing bug that I'm seeing in my SFBAudioEngine-using app in the field. I've tried to make it as easy as possible to reproduce and merge. Please let me know if you need anything else!)_

### Summary

`AudioPlayer::handleAudioEngineConfigurationChange` reconnects the main mixer node to the output node using the output node's current output format. When the output route is being torn down — a route change, an interruption, or the audio session being deactivated — that format transiently reports **0 Hz and/or 0 channels**. `-[AVAudioEngine connect:to:format:]` then fails its internal precondition `IsFormatSampleRateAndChannelCountValid(format)` and raises an Objective-C exception. Because `handleAudioEngineConfigurationChange` is declared `noexcept`, the exception cannot unwind and the process is terminated (`std::terminate` → `SIGABRT`).

This change guards the reconnection: the mixer→output connection is only rebuilt while the output node reports a usable format. When the format is invalid the reconfiguration is skipped and logged; `AVAudioEngine` posts a fresh `AVAudioEngineConfigurationChangeNotification` once valid output hardware is available, and that pass performs the reconnection. The existing "restart the engine if it was previously running" logic is unchanged, so playback still resumes.

### Crash signature

```
required condition is false: IsFormatSampleRateAndChannelCountValid(format)
  _AVAE_CheckAndReturnErr
  AVAudioEngineGraph::_Connect(...)
  -[AVAudioEngine connect:to:format:]
  sfb::AudioPlayer::handleAudioEngineConfigurationChange(...)   ← noexcept
  __exceptionPreprocess / objc_exception_throw → std::terminate → SIGABRT
```

### Root cause

```objc
AVAudioFormat *outputNodeOutputFormat = [outputNode outputFormatForBus:0];   // can be 0 Hz / 0 ch
AVAudioFormat *mixerNodeOutputFormat  = [mixerNode  outputFormatForBus:0];   // last valid format

if (outputNodeOutputFormat.sampleRate  != mixerNodeOutputFormat.sampleRate ||
    outputNodeOutputFormat.channelCount != mixerNodeOutputFormat.channelCount) {
    ...
    [engine_ connect:mixerNode to:outputNode format:outputNodeOutputFormat];  // ← aborts on 0/0
}
```

The guard asks only whether the format *differs*, never whether it is *usable*. An invalid `0/0` format always differs from the previously valid mixer format, so the mismatch branch is always taken and the invalid format flows straight into `connect:to:format:`.

This is the sibling of the guard a few lines above —

```objc
if (engine_.isRunning) { [engine_ stop]; }   // avoids the disconnect-while-running exception
```

— the *next* precondition in the same method that a transient hardware state can trip.
That guard (#907) made `disconnectNodeInput:` survivable; this one makes the following
`connect:to:format:` survivable.

### How it reproduces

My app is an iOS music player that **deactivates its `AVAudioSession` while an `SFBAudioPlayer` is still attached**, on backgrounding, so that Control Center reflects true rendering state rather than `playbackRate`. Deactivating the session tears down the output route, so `-[outputNode outputFormatForBus:0]` reports `0 Hz / 0 ch` at exactly the moment the resulting configuration-change notification is delivered.

That ordering appears to be why this has gone unreported: most clients keep the session active for the lifetime of the player, so they never observe the output node in this state.

Deterministic repro:

1. Begin playback through an `SFBAudioPlayer`.
2. With the player still attached, deactivate the audio session
   (`[[AVAudioSession sharedInstance] setActive:NO ...]`) — e.g. from
   `UIApplicationWillResignActiveNotification`.
3. The configuration-change notification arrives with an invalid output format and the
   process aborts.

Field data: a low but steady rate across several users, unchanged over four consecutive app releases, on both iOS 26.x and iOS 27, across four iPhone hardware generations, so it is neither OS-specific nor device-specific. Every sampled crash ends with the app transitioning to background, i.e. at session deactivation.

### Testing

- **Builds clean.** `swift build --target CSFBAudioEngine` succeeds on the patched branch (Swift 6.4 / Xcode 27, macOS 27), with no new warnings.
- **Code inspection** against the crash stack: this is the only `connect:to:format:` in the handler, and the format originates from the hardware output bus.
- **Not covered by a unit test.** The triggering condition is a hardware-derived format from a real output bus and cannot be injected through any public API, so there is no headless test for it. The change is a pure precondition on values already in hand.
- **No field soak yet.** I am pinning this branch now, but the crash is infrequent enough that a meaningful soak is weeks away. I did not want to claim a confirmation that does not exist — happy to report back once there is one.

### Notes

- Behavior is unchanged for every valid format: the added conjunct can only be false when the hardware format is unusable.
- No public API change.
- The skip path logs via `os_log_error` so the condition is visible rather than silent.
